### PR TITLE
linebreak long function signatures

### DIFF
--- a/Sources/MarkdownABI/Bytecode/MarkdownBytecode.Context.swift
+++ b/Sources/MarkdownABI/Bytecode/MarkdownBytecode.Context.swift
@@ -55,6 +55,9 @@ extension MarkdownBytecode
         case `class`
         case type
         case `typealias`
+        /// Argument label, used to line-break long function signatures.
+        /// New in 8.0.
+        case label
 
         //  Section elements.
         case parameters = 0xC0

--- a/Sources/MarkdownRendering/MarkdownElementContext.swift
+++ b/Sources/MarkdownRendering/MarkdownElementContext.swift
@@ -92,6 +92,7 @@ extension MarkdownElementContext
         case .identifier:       self = .highlight(.identifier,      attributes: &attributes)
         case .interpolation:    self = .highlight(.interpolation,   attributes: &attributes)
         case .keyword:          self = .highlight(.keyword,         attributes: &attributes)
+        case .label:            self = .highlight(.label,           attributes: &attributes)
         case .literalNumber:    self = .highlight(.literalNumber,   attributes: &attributes)
         case .literalString:    self = .highlight(.literalString,   attributes: &attributes)
         case .magic:            self = .highlight(.magic,           attributes: &attributes)

--- a/Sources/MarkdownRendering/MarkdownSyntaxHighlight.swift
+++ b/Sources/MarkdownRendering/MarkdownSyntaxHighlight.swift
@@ -9,6 +9,7 @@ enum MarkdownSyntaxHighlight:String, Equatable, Hashable, Sendable
     case identifier     = "syntax-identifier"
     case interpolation  = "syntax-interpolation"
     case keyword        = "syntax-keyword"
+    case label          = "syntax-label"
     case literalNumber  = "syntax-literal-number"
     case literalString  = "syntax-literal-string"
     case magic          = "syntax-magic"

--- a/Sources/SymbolGraphParts/Signatures/Signature.Abridged (ext).swift
+++ b/Sources/SymbolGraphParts/Signatures/Signature.Abridged (ext).swift
@@ -10,12 +10,18 @@ extension Signature<Symbol.Decl>.Abridged
         {
             for fragment:Signature.Fragment in fragments
             {
-                if  fragment.nominal
+                switch  (fragment.color, fragment.spelling)
                 {
+                case    (.identifier, _),
+                        (.keyword, "init"),
+                        (.keyword, "deinit"),
+                        (.keyword, "subscript"):
                     $0[.identifier] = fragment.spelling
-                }
-                else
-                {
+
+                case    (.label, _):
+                    $0[.label] = fragment.spelling
+
+                case    _:
                     $0 += fragment.spelling
                 }
             }

--- a/Sources/SymbolGraphParts/Signatures/Signature.Fragment.Color.swift
+++ b/Sources/SymbolGraphParts/Signatures/Signature.Fragment.Color.swift
@@ -60,7 +60,7 @@ extension Signature.Fragment.Color
         case .binding:          return .binding
         case .identifier:       return .identifier
         case .keyword:          return .keyword
-        case .label:            return .identifier
+        case .label:            return .label
         case .text:             return nil
         case .typeIdentifier:   return .type
         case .typeParameter:    return .typealias

--- a/Sources/SymbolGraphParts/Signatures/Signature.Fragment.swift
+++ b/Sources/SymbolGraphParts/Signatures/Signature.Fragment.swift
@@ -25,24 +25,6 @@ extension Signature<Symbol.Decl>
 }
 extension Signature.Fragment
 {
-    var nominal:Bool
-    {
-        switch  (self.color, self.spelling)
-        {
-        case    (.label, _),
-                (.identifier, _),
-                (.keyword, "init"),
-                (.keyword, "deinit"),
-                (.keyword, "subscript"):
-            return true
-
-        case _:
-            return false
-        }
-    }
-}
-extension Signature.Fragment
-{
     func spelled(_ spelling:__owned String) -> Self
     {
         .init(spelling, referent: self.referent, color: self.color)


### PR DESCRIPTION
* Adds a new markdown syntax highlight code `label`. Symbol graphs of ABI version 8.0 or greater will use the new highlight code instead of `identifier`.