### PR TITLE
fix #202

### DIFF
--- a/Sources/SymbolGraphBuilder/Builds/SSGC.DocumentationBuildError.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.DocumentationBuildError.swift
@@ -3,6 +3,7 @@ extension SSGC
     @frozen public
     enum DocumentationBuildError:Error
     {
+        case scanning(any Error)
         case loading(any Error)
         case linking(any Error)
     }
@@ -14,6 +15,7 @@ extension SSGC.DocumentationBuildError
     {
         switch self
         {
+        case .scanning(let error):  error
         case .loading(let error):   error
         case .linking(let error):   error
         }

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
@@ -314,6 +314,14 @@ extension SSGC.PackageBuild:SSGC.DocumentationBuild
             display: manifest.name,
             root: manifest.root)
 
-        return (metadata, try .init(scanning: flatNode, include: include))
+        //  This step is considered part of documentation building.
+        do
+        {
+            return (metadata, try .init(scanning: flatNode, include: include))
+        }
+        catch let error
+        {
+            throw SSGC.DocumentationBuildError.scanning(error)
+        }
     }
 }

--- a/Sources/SymbolGraphBuilder/SSGC.Main.swift
+++ b/Sources/SymbolGraphBuilder/SSGC.Main.swift
@@ -179,6 +179,7 @@ extension SSGC.Main
             {
                 switch error
                 {
+                case .scanning: return .failedToLoadSymbolGraph
                 case .loading:  return .failedToLoadSymbolGraph
                 case .linking:  return .failedToLinkSymbolGraph
                 }

--- a/Sources/SymbolGraphBuilder/Sources/SSGC.NominalSources.DefaultDirectory.swift
+++ b/Sources/SymbolGraphBuilder/Sources/SSGC.NominalSources.DefaultDirectory.swift
@@ -1,0 +1,43 @@
+import SymbolGraphs
+import System
+
+extension SSGC.NominalSources
+{
+    enum DefaultDirectory:Equatable, Hashable
+    {
+        case plugins
+        case snippets
+        case sources
+        case tests
+    }
+}
+extension SSGC.NominalSources.DefaultDirectory
+{
+    init?(for type:SymbolGraph.ModuleType)
+    {
+        switch type
+        {
+        case .binary:       return nil
+        case .executable:   self = .sources
+        case .regular:      self = .sources
+        case .macro:        self = .sources
+        case .plugin:       self = .plugins
+        case .snippet:      self = .snippets
+        case .system:       self = .sources
+        case .test:         self = .tests
+        }
+    }
+}
+extension SSGC.NominalSources.DefaultDirectory
+{
+    var name:FilePath.Component
+    {
+        switch self
+        {
+        case .plugins:  "Plugins"
+        case .snippets: "Snippets"
+        case .sources:  "Sources"
+        case .tests:    "Tests"
+        }
+    }
+}

--- a/Sources/SymbolGraphBuilder/Sources/SSGC.PackageSources.swift
+++ b/Sources/SymbolGraphBuilder/Sources/SSGC.PackageSources.swift
@@ -37,13 +37,23 @@ extension SSGC.PackageSources
 
         self.init(include: include, root: root)
 
+        let count:[SSGC.NominalSources.DefaultDirectory: Int] = package.modules.reduce(
+            into: [:])
+        {
+            if  case nil = $1.location,
+                let directory:SSGC.NominalSources.DefaultDirectory = .init(for: $1.type)
+            {
+                $0[directory, default: 0] += 1
+            }
+        }
         for i:Int in package.modules.indices
         {
             self.cultures.append(try .init(
                 include: &self.include,
                 exclude: package.exclude[i],
                 package: root,
-                module: package.modules[i]))
+                module: package.modules[i],
+                count: count))
         }
 
         guard

--- a/Sources/System/FilePath.DirectoryIterator.Stream.swift
+++ b/Sources/System/FilePath.DirectoryIterator.Stream.swift
@@ -40,7 +40,7 @@ extension FilePath.DirectoryIterator.Stream
                     return nil
 
                 case let error:
-                    throw error
+                    throw FileError.opening(path, error)
                 }
             }
             self = .opened(pointer)


### PR DESCRIPTION
this fixes #202 and more generally, enables documentation generation for packages using the deprecated SwiftPM single-module layout