### PR TITLE
Relative link sibling articles

### DIFF
--- a/Sources/UnidocUI/Page contexts/Unidoc.AbsolutePageContext.swift
+++ b/Sources/UnidocUI/Page contexts/Unidoc.AbsolutePageContext.swift
@@ -1,5 +1,6 @@
 import UnidocRender
 import UnidocRecords
+import URI
 
 extension Unidoc
 {
@@ -21,7 +22,28 @@ extension Unidoc
         public override
         subscript(article id:Unidoc.Scalar) -> Unidoc.LinkReference<Unidoc.ArticleVertex>?
         {
-            super[article: id]?.map { "https://swiftinit.org\($0)" }
+            guard
+            let link:Unidoc.LinkReference<Unidoc.ArticleVertex> = super[article: id]
+            else
+            {
+                return nil
+            }
+
+            return link.map
+            {
+                if  self.volume.id == id.edition
+                {
+                    //  This is a link to an article in the same volume. Most likely, the API
+                    //  user wants to also host the other article under the same domain. Because
+                    //  we know article paths are at most one component deep, we can just return
+                    //  the last component of other article’s path as a relative URI.
+                    return "../\(URI.Path.Component.push(link.vertex.stem.last.lowercased()))"
+                }
+                else
+                {
+                    return "https://swiftinit.org\($0)"
+                }
+            }
         }
 
         public override

--- a/Sources/UnidocUI/Page contexts/Unidoc.AbsolutePageContext.swift
+++ b/Sources/UnidocUI/Page contexts/Unidoc.AbsolutePageContext.swift
@@ -10,13 +10,21 @@ extension Unidoc
         public override
         subscript(vertex id:Unidoc.Scalar) -> Unidoc.LinkReference<Unidoc.AnyVertex>?
         {
-            super[vertex: id]?.map { "https://swiftinit.org\($0)" }
-        }
+            guard
+            let link:Unidoc.LinkReference<Unidoc.AnyVertex> = super[vertex: id]
+            else
+            {
+                return nil
+            }
 
-        public override
-        subscript(culture id:Unidoc.Scalar) -> Unidoc.LinkReference<Unidoc.CultureVertex>?
-        {
-            super[culture: id]?.map { "https://swiftinit.org\($0)" }
+            if  case .article(let article) = link.vertex
+            {
+                return link.map { self.rewrite($0, to: article) }
+            }
+            else
+            {
+                return link.map(Self.rewrite(_:))
+            }
         }
 
         public override
@@ -29,27 +37,45 @@ extension Unidoc
                 return nil
             }
 
-            return link.map
-            {
-                if  self.volume.id == id.edition
-                {
-                    //  This is a link to an article in the same volume. Most likely, the API
-                    //  user wants to also host the other article under the same domain. Because
-                    //  we know article paths are at most one component deep, we can just return
-                    //  the last component of other article’s path as a relative URI.
-                    return "../\(URI.Path.Component.push(link.vertex.stem.last.lowercased()))"
-                }
-                else
-                {
-                    return "https://swiftinit.org\($0)"
-                }
-            }
+            return link.map { self.rewrite($0, to: link.vertex) }
+        }
+
+        public override
+        subscript(culture id:Unidoc.Scalar) -> Unidoc.LinkReference<Unidoc.CultureVertex>?
+        {
+            super[culture: id]?.map(Self.rewrite(_:))
         }
 
         public override
         subscript(decl id:Unidoc.Scalar) -> Unidoc.LinkReference<Unidoc.DeclVertex>?
         {
-            super[decl: id]?.map { "https://swiftinit.org\($0)" }
+            super[decl: id]?.map(Self.rewrite(_:))
+        }
+    }
+}
+extension Unidoc.AbsolutePageContext
+{
+    @inline(__always)
+    private static
+    func rewrite(_ uri:String) -> String
+    {
+        "https://swiftinit.org\(uri)"
+    }
+
+    private
+    func rewrite(_ uri:String, to article:Unidoc.ArticleVertex) -> String
+    {
+        if  self.volume.id == article.id.edition
+        {
+            //  This is a link to an article in the same volume. Most likely, the API
+            //  user wants to also host the other article under the same domain. Because
+            //  we know article paths are at most one component deep, we can just return
+            //  the last component of the other article’s path as a relative URI.
+            return "../\(URI.Path.Component.push(article.stem.last.lowercased()))"
+        }
+        else
+        {
+            return Self.rewrite(uri)
         }
     }
 }


### PR DESCRIPTION
resolves #205 

when using the render API, if unidoc detects a link that resolves to an article in the same package, it will emit a relative URI of the form `../other-article-name`, which assumes the client is using a “sane” website layout with all articles under the same URL prefix