### PR TITLE
indexstore-db preparation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "822aba0dca0db107a4467742b739c95eaf48952d4d0a98df62751bce2e307f21",
+  "originHash" : "d4f1a09da971c4825165917441100323845fb650b60b9dfd4a50f871e2b84f31",
   "pins" : [
     {
       "identity" : "swift-atomics",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -102,9 +102,11 @@ let package:Package = .init(
         .package(url: "https://github.com/tayloraswift/swift-png", .upToNextMinor(
             from: "4.4.1")),
 
+        // .package(url: "https://github.com/apple/indexstore-db",
+        //     branch: "swift-5.10-RELEASE"),
+
         .package(url: "https://github.com/apple/swift-atomics", .upToNextMinor(
             from: "1.2.0")),
-
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(
             from: "1.1.0")),
 
@@ -120,7 +122,7 @@ let package:Package = .init(
         .package(url: "https://github.com/apple/swift-system", .upToNextMinor(
             from: "1.2.1")),
         .package(url: "https://github.com/apple/swift-syntax",
-            exact: "510.0.1"),
+            exact: "510.0.2"),
     ],
     targets: [
         .macro(name: "UnidocMacros",
@@ -299,6 +301,12 @@ let package:Package = .init(
                 .product(name: "SwiftParser", package: "swift-syntax"),
             ]),
 
+        .target(name: "MarkdownPluginSwift_IndexStoreDB",
+            dependencies: [
+                .target(name: "MarkdownPluginSwift"),
+                // .product(name: "IndexStoreDB", package: "indexstore-db"),
+            ]),
+
         .target(name: "MarkdownSemantics",
             dependencies: [
                 .target(name: "MarkdownAST"),
@@ -384,6 +392,7 @@ let package:Package = .init(
             dependencies: [
                 .target(name: "ArgumentParsing"),
                 .target(name: "MarkdownPluginSwift"),
+                .target(name: "MarkdownPluginSwift_IndexStoreDB"),
                 .target(name: "PackageMetadata"),
                 .target(name: "SymbolGraphCompiler"),
                 .target(name: "SymbolGraphLinker"),

--- a/Sources/MarkdownPluginSwift/Markdown.CodeLanguageType (ext).swift
+++ b/Sources/MarkdownPluginSwift/Markdown.CodeLanguageType (ext).swift
@@ -3,5 +3,11 @@ import MarkdownABI
 extension Markdown.CodeLanguageType where Self == Markdown.SwiftLanguage
 {
     @inlinable public static
-    var swift:Self { .init() }
+    var swift:Self { .swift(index: nil) }
+
+    @inlinable public static
+    func swift(index:(any Markdown.SwiftLanguage.IndexStore)?) -> Self
+    {
+        .init(index: index)
+    }
 }

--- a/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexStore.swift
+++ b/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexStore.swift
@@ -1,0 +1,8 @@
+extension Markdown.SwiftLanguage
+{
+    public
+    protocol IndexStore:AnyObject
+    {
+        func load(for path:String)
+    }
+}

--- a/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.swift
+++ b/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.swift
@@ -3,15 +3,20 @@ import Snippets
 import SwiftIDEUtils
 import SwiftParser
 import SwiftSyntax
+import Symbols
 
 extension Markdown
 {
     @frozen public
     struct SwiftLanguage
     {
-        @inlinable internal
-        init()
+        @usableFromInline
+        let index:(any IndexStore)?
+
+        @inlinable
+        init(index:(any IndexStore)? = nil)
         {
+            self.index = index
         }
     }
 }
@@ -26,8 +31,14 @@ extension Markdown.SwiftLanguage:Markdown.CodeLanguageType
 extension Markdown.SwiftLanguage
 {
     public
-    func parse(snippet utf8:[UInt8]) -> (caption:String, slices:[Markdown.SnippetSlice])
+    func parse(snippet utf8:[UInt8],
+        from indexID:String? = nil) -> (caption:String, slices:[Markdown.SnippetSlice])
     {
+        if  let indexID:String
+        {
+            self.index?.load(for: indexID)
+        }
+
         //  It is safe to escape the pointer to ``Parser.parse(source:maximumNestingLevel:)``,
         //  see: https://swiftinit.org/docs/swift-syntax/swiftparser/parser.init(_:maximumnestinglevel:parsetransition:arena:)
         let parsed:SourceFileSyntax = utf8.withUnsafeBufferPointer

--- a/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
+++ b/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
@@ -1,0 +1,21 @@
+#if canImport(IndexStoreDB)
+
+import IndexStoreDB
+import MarkdownPluginSwift
+
+extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
+{
+    public
+    func load(for id:String)
+    {
+        for symbol:Symbol in self.symbols(inFilePath: id)
+        {
+            for occurence:SymbolOccurrence in self.occurrences(ofUSR: symbol.usr, roles: .all)
+            {
+                print(occurence)
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.Configuration.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.Configuration.swift
@@ -1,17 +1,17 @@
-extension SSGC.PackageBuild
+extension SSGC
 {
     @frozen public
-    enum Configuration:String
+    enum PackageBuildConfiguration:String
     {
         case debug = "debug"
     }
 }
-extension SSGC.PackageBuild.Configuration:CustomStringConvertible
+extension SSGC.PackageBuildConfiguration:CustomStringConvertible
 {
     @inlinable public
     var description:String { self.rawValue }
 }
-extension SSGC.PackageBuild.Configuration:LosslessStringConvertible
+extension SSGC.PackageBuildConfiguration:LosslessStringConvertible
 {
     @inlinable public
     init?(_ description:String) { self.init(rawValue: description) }

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
@@ -31,12 +31,6 @@ extension SSGC
 }
 extension SSGC.PackageBuild
 {
-    /// Always returns ``Configuration/debug``.
-    private
-    var configuration:Configuration { .debug }
-}
-extension SSGC.PackageBuild
-{
     func listExtraManifests() throws -> [MinorVersion]
     {
         var versions:[MinorVersion] = []
@@ -219,9 +213,7 @@ extension SSGC.PackageBuild:SSGC.DocumentationBuild
         let scratch:SSGC.PackageBuildDirectory
         do
         {
-            scratch = try swift.build(package: self.root,
-                configuration: self.configuration,
-                flags: self.flags)
+            scratch = try swift.build(package: self.root, flags: self.flags)
         }
         catch SystemProcessError.exit(let code, let invocation)
         {
@@ -231,7 +223,7 @@ extension SSGC.PackageBuild:SSGC.DocumentationBuild
         let platform:SymbolGraphMetadata.Platform = try swift.platform()
 
         var dependencies:[PackageNode] = []
-        var include:[FilePath] = [ scratch.path / "\(self.configuration)" ]
+        var include:[FilePath] = [scratch.include]
 
         //  Nominal dependencies mean we need to perform two passes.
         var packageContainingProduct:[String: Symbol.Package] = [:]
@@ -329,7 +321,7 @@ extension SSGC.PackageBuild:SSGC.DocumentationBuild
         //  This step is considered part of documentation building.
         do
         {
-            return (metadata, try .init(scanning: flatNode, include: include))
+            return (metadata, try .init(scanning: flatNode, include: include, scratch: scratch))
         }
         catch let error
         {

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuildDirectory.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuildDirectory.swift
@@ -5,6 +5,17 @@ extension SSGC
     /// An SPM build directory. It is usually, but not always, named `.build`.
     struct PackageBuildDirectory
     {
+        let configuration:PackageBuildConfiguration
         let path:FilePath
+
+        init(configuration:PackageBuildConfiguration, path:FilePath)
+        {
+            self.configuration = configuration
+            self.path = path
+        }
     }
+}
+extension SSGC.PackageBuildDirectory
+{
+    var include:FilePath { self.path / "\(self.configuration)" }
 }

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
@@ -1,3 +1,12 @@
+#if canImport(IndexStoreDB)
+
+import class IndexStoreDB.IndexStoreDB
+import class IndexStoreDB.IndexStoreLibrary
+import MarkdownPluginSwift_IndexStoreDB
+
+#endif
+
+import MarkdownABI
 import SymbolGraphs
 import System
 
@@ -76,9 +85,31 @@ extension SSGC.Workspace
             include: package.include,
             output: output)
 
+        #if canImport(IndexStoreDB)
+
+        let index:(any Markdown.SwiftLanguage.IndexStore)? = try package.scratch.map
+        {
+            let libIndexStore:IndexStoreLibrary = try swift.libIndexStore()
+            let indexPath:FilePath = $0.include / "index"
+            return try IndexStoreDB.init(storePath: "\(indexPath)/store",
+                databasePath: "\(indexPath)/db",
+                library: libIndexStore,
+                waitUntilDoneInitializing: true,
+                readonly: false,
+                listenToUnitEvents: true)
+        }
+
+        #else
+
+        let index:(any Markdown.SwiftLanguage.IndexStore)? = nil
+
+        #endif
+
         let compiled:SymbolGraph = try .compile(artifacts: artifacts,
             package: package,
-            logger: logger)
+            logger: logger,
+            index: index)
+
 
         return .init(metadata: metadata, graph: compiled)
     }

--- a/Sources/SymbolGraphBuilder/Sources/SSGC.LazyFile.swift
+++ b/Sources/SymbolGraphBuilder/Sources/SSGC.LazyFile.swift
@@ -12,18 +12,18 @@ extension SSGC
         private(set)
         var loadingTime:Duration
         private
-        let location:FilePath
-        private
         var content:[UInt8]?
 
+        let location:FilePath
         let path:Symbol.File
         let name:String
 
         init(location:FilePath, path:Symbol.File, name:String)
         {
             self.loadingTime = .zero
-            self.location = location
             self.content = nil
+
+            self.location = location
             self.path = path
             self.name = name
         }

--- a/Sources/SymbolGraphBuilder/Sources/SSGC.PackageSources.swift
+++ b/Sources/SymbolGraphBuilder/Sources/SSGC.PackageSources.swift
@@ -12,12 +12,14 @@ extension SSGC
 
         var include:[FilePath]
 
+        let scratch:PackageBuildDirectory?
         let root:PackageRoot?
 
         init(
             cultures:[NominalSources] = [],
             snippets:[LazyFile] = [],
             include:[FilePath] = [],
+            scratch:PackageBuildDirectory? = nil,
             root:PackageRoot? = nil)
         {
             self.cultures = cultures
@@ -25,17 +27,20 @@ extension SSGC
 
             self.include = include
 
+            self.scratch = scratch
             self.root = root
         }
     }
 }
 extension SSGC.PackageSources
 {
-    init(scanning package:borrowing PackageNode, include:consuming [FilePath] = []) throws
+    init(scanning package:borrowing PackageNode,
+        include:consuming [FilePath] = [],
+        scratch:consuming SSGC.PackageBuildDirectory? = nil) throws
     {
         let root:SSGC.PackageRoot = .init(normalizing: package.root)
 
-        self.init(include: include, root: root)
+        self.init(include: include, scratch: scratch, root: root)
 
         let count:[SSGC.NominalSources.DefaultDirectory: Int] = package.modules.reduce(
             into: [:])

--- a/Sources/SymbolGraphBuilder/SymbolGraph (ext).swift
+++ b/Sources/SymbolGraphBuilder/SymbolGraph (ext).swift
@@ -14,7 +14,8 @@ extension SymbolGraph
     static
     func compile(artifacts:[Artifacts],
         package:SSGC.PackageSources,
-        logger:SSGC.DocumentationLogger?) throws -> Self
+        logger:SSGC.DocumentationLogger?,
+        index:(any Markdown.SwiftLanguage.IndexStore)? = nil) throws -> Self
     {
         precondition(package.cultures.count == artifacts.count,
             "Mismatched cultures and artifacts!")
@@ -72,7 +73,8 @@ extension SymbolGraph
         {
             var linker:SSGC.Linker = .init(nominations: nominations,
                 modules: package.cultures.map(\.module),
-                plugins: [.swift])
+                plugins: [.swift(index: index)],
+                root: root)
 
             let namespacePositions:[[SymbolGraph.Namespace]] = profiler.measure(\.linking)
             {
@@ -126,11 +128,11 @@ extension SymbolGraph
 
             if  let logger:SSGC.DocumentationLogger
             {
-                try logger.emit(messages: linker.status(root: root))
+                try logger.emit(messages: linker.status())
             }
             else
             {
-                linker.status(root: root).emit(colors: .enabled)
+                linker.status().emit(colors: .enabled)
             }
 
             print("""

--- a/Sources/SymbolGraphBuilder/Toolchains/SSGC.Toolchain.swift
+++ b/Sources/SymbolGraphBuilder/Toolchains/SSGC.Toolchain.swift
@@ -1,3 +1,9 @@
+#if canImport(IndexStoreDB)
+
+import class IndexStoreDB.IndexStoreLibrary
+
+#endif
+
 import JSON
 import PackageGraphs
 import PackageMetadata
@@ -168,6 +174,16 @@ extension SSGC.Toolchain
 }
 extension SSGC.Toolchain
 {
+    #if canImport(IndexStoreDB)
+
+    func libIndexStore() throws -> IndexStoreLibrary
+    {
+        /// FIXME: this is almost certain to fail on macOS
+        try .init(dylibPath: "/usr/lib/libIndexStore.so")
+    }
+
+    #endif
+
     func platform() throws -> SymbolGraphMetadata.Platform
     {
         if      self.triple.os.starts(with: "linux")
@@ -261,16 +277,17 @@ extension SSGC.Toolchain
         }
     }
 
-    func build(package:FilePath,
-        configuration:SSGC.PackageBuild.Configuration = .debug,
+    func build(
+        package:FilePath,
         flags:SSGC.PackageBuild.Flags = .init()) throws -> SSGC.PackageBuildDirectory
     {
-        let scratch:SSGC.PackageBuildDirectory = .init(path: package / self.scratch)
+        let scratch:SSGC.PackageBuildDirectory = .init(configuration: .debug,
+            path: package / self.scratch)
 
         var arguments:[String] =
         [
             "build",
-            "--configuration", "\(configuration)",
+            "--configuration", "\(scratch.configuration)",
             "--package-path", "\(package)",
             "--scratch-path", "\(scratch.path)",
         ]

--- a/Sources/SymbolGraphLinker/Resources/SSGC.ResourceFile.swift
+++ b/Sources/SymbolGraphLinker/Resources/SSGC.ResourceFile.swift
@@ -14,8 +14,8 @@ extension SSGC
         /// The path to the resource file, relative to the package root.
         var path:Symbol.File { get }
 
-        /// The name of the resource file. This is a scalar string and should not include any path
-        /// separators. It only needs to be unique within a single module.
+        /// The name of the resource file. This is a scalar string and should not include any
+        /// path separators. It only needs to be unique within a single module.
         var name:String { get }
     }
 }

--- a/TestPackages/swift-snippets/Package.swift
+++ b/TestPackages/swift-snippets/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package:Package = .init(name: "Swift Unidoc Snippets Test Package",
+    products:
+    [
+    ],
+    targets:
+    [
+    ])

--- a/TestPackages/swift-snippets/Snippets/Snippet.swift
+++ b/TestPackages/swift-snippets/Snippets/Snippet.swift
@@ -1,0 +1,4 @@
+enum E
+{
+    case a
+}


### PR DESCRIPTION
this PR lands most of the far-reaching changes i anticipate that we will need for IndexStoreDB integration, without breaking compilation due to the complexities of depending on IndexStoreDB.

all of the IndexStoreDB-dependent stuff is currently gated by `#if canImport(IndexStoreDB)`. to enable the IndexStoreDB stuff, uncomment the `indexstore-db` package dependency, and the `.product(name: "IndexStoreDB", package: "indexstore-db"),` dependency of the `MarkdownPluginSwift_IndexStoreDB` target. 

## tasks

the IndexStore integration is **not** anywhere near a state where we can ship it; there are many outstanding issues that need to be solved and algorithms that need to be written. the purpose of this PR is to enable us to work on it in a branch that touches a smaller subset of the code base.

- [ ] in `SSGC.Toolchain.swift`, we have hardcoded the path `/usr/lib/libIndexStore.so`, which is Linux-specific. `SSGC.Toolchain` does not know how to locate the Swift runtime and will need to become able to do so.

- [ ] in the `MarkdownPluginSwift` module, we need to somehow correlate two-dimensional `SymbolOccurrence`s with SwiftSyntax’s one-dimensional syntax classifications, which are already non-contiguous due to Snippet slicing and de-indentation. 

    this could be complicated, because `MarkdownPluginSwift` is already cutting `SnippetParser.Slice` ranges out of `SyntaxClassificationCursor` (making the highlights non-contiguous with respect to the original source text), so there is a lot of tough computational geometry that needs to be implemented here. 

    on the bright side, this should be a relatively self-contained task that doesn’t require understanding anything outside the `MarkdownPluginSwift` module, except for the Markdown bytecode ABI.

- [ ] depending on how aggressively we want to link identifiers in the Snippets, we probably also to intern the USRs pulled out of the Snippets by the `Markdown.SwiftLanguage` plugin, and add them to the Symbol Graph reference table. but this can wait until after we have implemented the range intersection algorithm described in the previous bullet.

- [ ] unidoc becomes really difficult to build and test due to the extra C++ flags, and it becomes impossible to use swift-unidoc as a SwiftPM library because indexstore-db has no stable releases. we need to figure that out before merging this stuff into `master`.

## iteration 

this PR includes a small test project `TestPackages/swift-snippets`.

```
$ swift run -Xcxx -I/usr/lib/swift -Xcxx -I/usr/lib/swift/Block unidoc-build local swift-snippets -I TestPackages/
```

right now the stub implementation just dumps the 2D coordinates of the IndexStore symbols:

```text
Connecting to localhost:8443...
Dumping manifest for package 'swift-snippets' (unversioned)
Resolving dependencies for 'swift-snippets' (swift-tools-version: 5.10.0)
Everything is already up-to-date
Building for debugging...
[1/1] Write swift-version-24593BA9C3E375BF.txt
Build complete! (0.16s)
Compiled documentation!
    time loading symbols    : 0.0 seconds
    time compiling          : 0.0 seconds
cultures        : 0
namespaces      : 0
declarations    : 0
extensions      : 0
Loading file Snippets/Snippet.swift ...
Snippet::/swift/swift-unidoc/TestPackages/swift-snippets/Snippets/Snippet.swift:1:6 | E | enum | s:7Snippet1EO | [def|canon]
Snippet::/swift/swift-unidoc/TestPackages/swift-snippets/Snippets/Snippet.swift:3:10 | a | enumConstant | s:7Snippet1EO1ayA2CmF | [def|childOf|canon]
        [childOf] | s:7Snippet1EO

Linked documentation!
    time loading sources    : 4.1626e-05 seconds
    time linking            : 0.008805889 seconds
symbols         : 0
```