### PR TITLE
lift the one-stable-release requirement

### DIFF
--- a/Sources/UnidocQueries/Volumes/Unidoc.PrincipalOutput.swift
+++ b/Sources/UnidocQueries/Volumes/Unidoc.PrincipalOutput.swift
@@ -13,15 +13,10 @@ extension Unidoc
     {
         public
         let matches:[AnyVertex]
-
         public
         let vertex:AnyVertex?
         public
-        let vertexInLatest:AnyVertex?
-
-        public
         let groups:[AnyGroup]
-
         public
         let volume:VolumeMetadata
         public
@@ -34,19 +29,14 @@ extension Unidoc
         init(
             matches:[AnyVertex],
             vertex:AnyVertex?,
-            vertexInLatest:AnyVertex?,
             groups:[AnyGroup],
             volume:VolumeMetadata,
             volumeOfLatest:VolumeMetadata?,
             tree:TypeTree?)
         {
             self.matches = matches
-
             self.vertex = vertex
-            self.vertexInLatest = vertexInLatest
-
             self.groups = groups
-
             self.volume = volume
             self.volumeOfLatest = volumeOfLatest
 
@@ -61,7 +51,6 @@ extension Unidoc.PrincipalOutput:Mongo.MasterCodingModel
     {
         case matches = "A"
         case vertex = "M"
-        case vertexInLatest = "L"
         case groups = "G"
         case volume = "Z"
         case volumeOfLatest = "R"
@@ -76,7 +65,6 @@ extension Unidoc.PrincipalOutput:BSONDocumentDecodable
         self.init(
             matches: try bson[.matches].decode(),
             vertex: try bson[.vertex]?.decode(),
-            vertexInLatest: try bson[.vertexInLatest]?.decode(),
             groups: try bson[.groups].decode(),
             volume: try bson[.volume].decode(),
             volumeOfLatest: try bson[.volumeOfLatest]?.decode(),

--- a/Sources/UnidocQueries/Volumes/Unidoc.VertexOutput.swift
+++ b/Sources/UnidocQueries/Volumes/Unidoc.VertexOutput.swift
@@ -11,6 +11,8 @@ extension Unidoc
         public
         let principal:PrincipalOutput?
         public
+        let canonical:Unidoc.AnyVertex?
+        public
         let vertices:[Unidoc.AnyVertex]
         public
         let volumes:[Unidoc.VolumeMetadata]
@@ -19,11 +21,13 @@ extension Unidoc
 
         @inlinable public
         init(principal:PrincipalOutput?,
+            canonical:Unidoc.AnyVertex?,
             vertices:[Unidoc.AnyVertex],
             volumes:[Unidoc.VolumeMetadata],
             packages:[Unidoc.PackageMetadata])
         {
             self.principal = principal
+            self.canonical = canonical
             self.vertices = vertices
             self.volumes = volumes
             self.packages = packages
@@ -36,6 +40,7 @@ extension Unidoc.VertexOutput:Mongo.MasterCodingModel
     enum CodingKey:String, Sendable
     {
         case principal
+        case canonical
         case vertices
         case volumes
         case packages
@@ -48,6 +53,7 @@ extension Unidoc.VertexOutput:BSONDocumentDecodable
     {
         self.init(
             principal: try bson[.principal]?.decode(),
+            canonical: try bson[.canonical]?.decode(),
             vertices: try bson[.vertices].decode(),
             volumes: try bson[.volumes].decode(),
             packages: try bson[.packages].decode())

--- a/Sources/UnidocQueries/Volumes/Unidoc.VolumeQuery.swift
+++ b/Sources/UnidocQueries/Volumes/Unidoc.VolumeQuery.swift
@@ -142,12 +142,12 @@ extension Unidoc.VolumeQuery
                 }
                 $0[.as] = volumeOfLatest
             }
-            //  Unbox the single-element array. It must contain at least one element for the
-            //  query to have been successful, so we can simply use an `$unwind`.
-            //
-            //  One of the implications of this is that it is *impossible* to access unreleased
-            //  documentation if the package does not have at least one release in the database.
-            pipeline[stage: .unwind] = volumeOfLatest
+
+            //  Unbox the single-element array.
+            pipeline[stage: .set] = .init
+            {
+                $0[volumeOfLatest] = .expr { $0[.first] = volumeOfLatest }
+            }
         }
     }
 }

--- a/Sources/UnidocUI/Endpoints/Unidoc.VertexEndpoint.swift
+++ b/Sources/UnidocUI/Endpoints/Unidoc.VertexEndpoint.swift
@@ -84,6 +84,7 @@ extension Unidoc.VertexEndpoint where Self:HTTP.ServerEndpoint
         if  let vertex:Unidoc.AnyVertex = principal.vertex
         {
             let vertexContext:VertexContext = .init(canonical: .init(principal: principal,
+                    vertex: output.canonical,
                     layer: VertexLayer.self),
                 principal: principal.volume,
                 secondary: output.volumes,

--- a/Sources/UnidocUI/Unidoc.CanonicalVersion (ext).swift
+++ b/Sources/UnidocUI/Unidoc.CanonicalVersion (ext).swift
@@ -5,7 +5,9 @@ import URI
 
 extension Unidoc.CanonicalVersion
 {
-    init?(principal:Unidoc.PrincipalOutput, layer:(some Unidoc.VertexLayer).Type)
+    init?(principal:Unidoc.PrincipalOutput,
+        vertex:__shared Unidoc.AnyVertex?,
+        layer:(some Unidoc.VertexLayer).Type)
     {
         guard
         let volumeOfLatest:Unidoc.VolumeMetadata = principal.volumeOfLatest,
@@ -33,7 +35,7 @@ extension Unidoc.CanonicalVersion
 
         let target:Target
 
-        if  let vertex:Unidoc.AnyVertex = principal.vertexInLatest
+        if  let vertex:Unidoc.AnyVertex
         {
             switch vertex
             {


### PR DESCRIPTION
once this PR is merged, it should be possible to view documentation generated from branch or prerelease versions, even if no stable releases exist