### PR TITLE
CI documentation state change events (attempt 2)

### DIFF
--- a/Sources/UnidocDB/Snapshots/Unidoc.DB.Snapshots.swift
+++ b/Sources/UnidocDB/Snapshots/Unidoc.DB.Snapshots.swift
@@ -37,10 +37,14 @@ extension Unidoc.DB.Snapshots
     }
 
     public static
-    let indexSymbolGraphABI:Mongo.CollectionIndex = .init("ABI",
+    let indexSymbolGraphABI:Mongo.CollectionIndex = .init("ABI/2",
         unique: false)
     {
         $0[Unidoc.Snapshot[.metadata] / SymbolGraphMetadata[.abi]] = (+)
+    }
+        where:
+    {
+        $0[Unidoc.Snapshot[.metadata]] { $0[.exists] = true }
     }
 
     public static
@@ -211,6 +215,7 @@ extension Unidoc.DB.Snapshots
             {
                 $0[.filter]
                 {
+                    $0[Unidoc.Snapshot[.metadata]] { $0[.exists] = true }
                     $0[Unidoc.Snapshot[.metadata] / SymbolGraphMetadata[.abi]]
                     {
                         $0[.lt] = version

--- a/Sources/UnidocDB/Unidoc.DB.swift
+++ b/Sources/UnidocDB/Unidoc.DB.swift
@@ -15,10 +15,6 @@ import UnidocLinker
 import UnidocRecords
 import UnixTime
 
-@available(*, deprecated, renamed: "Unidoc.DB")
-public
-typealias UnidocDatabase = Unidoc.DB
-
 extension Unidoc
 {
     @frozen public

--- a/Sources/UnidocQueries/Versions/Unidoc.VersionState.Graph.swift
+++ b/Sources/UnidocQueries/Versions/Unidoc.VersionState.Graph.swift
@@ -29,7 +29,7 @@ extension Unidoc.VersionState
         public
         let commit:SHA1?
         public
-        let abi:PatchVersion
+        let abi:PatchVersion?
 
         @inlinable public
         init(id:Unidoc.Edition,
@@ -37,7 +37,7 @@ extension Unidoc.VersionState
             remoteBytes:Int,
             action:Unidoc.Snapshot.PendingAction?,
             commit:SHA1?,
-            abi:PatchVersion)
+            abi:PatchVersion?)
         {
             self.id = id
             self.inlineBytes = inlineBytes
@@ -71,6 +71,6 @@ extension Unidoc.VersionState.Graph:BSONDocumentDecodable
             remoteBytes: try bson[.remoteBytes].decode(),
             action: try bson[.action]?.decode(),
             commit: try bson[.commit]?.decode(),
-            abi: try bson[.abi].decode())
+            abi: try bson[.abi]?.decode())
     }
 }

--- a/Sources/UnidocRecords/Packages/Unidoc.Snapshot.swift
+++ b/Sources/UnidocRecords/Packages/Unidoc.Snapshot.swift
@@ -117,7 +117,8 @@ extension Unidoc.Snapshot
     }
 
     /// Wraps and returns the inline symbol graph from this snapshot document if present,
-    /// delegates to the provided symbol graph loader otherwise.
+    /// delegates to the provided symbol graph loader otherwise. Returns nil if the symbol graph
+    /// has not been built yet.
     public
     func load<Loader>(with loader:Loader?) async throws -> SymbolGraphObject<Unidoc.Edition>
         where Loader:Unidoc.GraphLoader

--- a/Sources/UnidocUI/Endpoints/Tags/Unidoc.RefsTable.Row.Graph.swift
+++ b/Sources/UnidocUI/Endpoints/Tags/Unidoc.RefsTable.Row.Graph.swift
@@ -1,5 +1,6 @@
 import HTML
 import Media
+import SemanticVersions
 import Symbols
 
 extension Unidoc.RefsTable.Row
@@ -46,7 +47,8 @@ extension Unidoc.RefsTable.Row.Graph:HTML.OutputStreamable
     {
         td[.div]
         {
-            guard case .some(let graph) = self.state
+            guard case .some(let graph) = self.state,
+            let abi:PatchVersion = graph.abi
             else
             {
                 $0[.span] { $0.title = "No symbol graph has been built for this version." }
@@ -80,7 +82,7 @@ extension Unidoc.RefsTable.Row.Graph:HTML.OutputStreamable
                     This symbol graph is currently queued for deletion.
                     """
                 }
-            } = "\(graph.abi)"
+            } = "\(abi)"
 
             $0 += " "
 


### PR DESCRIPTION
so, this has proven to be far more challenging than initially thought (#235). some notes in no particular order:

* we really should be sharding build logs by date rather than by package. this is something we need to do regardless of the state change APIs.
    - build logs should be per-edition, not per-package.

* our API clients (e.g. https://swiftonserver.com) want a linear storyline that goes something like “Fetch → Build → Link → Render”, however it seems everything in the database is laid out to inhibit this sort of workflow. in retrospect, this is unsurprising because these four components were designed to operate independently, and it is extraordinarily difficult to reliably collate activity across the various subsystems into a coherent “plot line”. 

* each subsystem is designed to keep operating even if the other subsystems are down or disabled, and to recover the backlog when they have been offline for some time (e.g. for maintenance). for external clients, this means it is easy to “lose the plot” so to speak.

* we have two choices of collection we could conceivably subscribe to broadcast the state change events - `Snapshots` and `VolumeMetadata`. both schema are designed to be written atomically, and neither of them have the capability to represent build state, including build failure. it would not be feasible to give them the ability to represent build state, because their schema are very hostile to the sort of streaming updates that build state involves.

* in practical terms, subscribing to them means API clients would only receive notifications of successful builds; they would hang forever if any of the steps in the documentation pipeline fail. in a sense, **this is how Unidoc was originally designed to operate**. for example, it is supposed to be okay to build symbol graphs even if the linker is offline - the linker may come back online again later and process the backlogged symbol graph.

* currently, the way we track build state is by streaming the updates to `BuildMetadata`. this collection is per-package, because the version to build is not chosen until midway through the build process. subscribing to `BuildMetadata` would tell us about build failures, but build state isn’t what our API clients are actually interested in - it is the link state that they care about, since they want to render the linked docs. there is also a gap between the time a build completes and the time the docs are ready to render, and there is still the possibility that linking itself could fail.