### PR TITLE
draft impl for indexstore-powered improved highlights

### DIFF
--- a/.github/pipeline
+++ b/.github/pipeline
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -e
+
 swift --version
-swift build -c release --explicit-target-dependency-import-check=error
+
+swift build -c release \
+    -explicit-target-dependency-import-check=error \
+    -Xcxx -I/usr/lib/swift \
+    -Xcxx -I/usr/lib/swift/Block
+
 ./generate-test-symbolgraphs
 for f in .build/release/*Tests; do
   $f

--- a/.github/pipeline
+++ b/.github/pipeline
@@ -4,7 +4,7 @@ set -e
 swift --version
 
 swift build -c release \
-    -explicit-target-dependency-import-check=error \
+    --explicit-target-dependency-import-check=error \
     -Xcxx -I/usr/lib/swift \
     -Xcxx -I/usr/lib/swift/Block
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,17 @@ jobs:
             -   name: Build debug
                 run: |
                     swift --version
-                    swift build
+                    swift build -Xcxx -I/usr/lib/swift -Xcxx -I/usr/lib/swift/Block
 
             -   name: Build release
                 run: |
-                    swift build -c release
+                    swift build -c release \
+                        -Xcxx -I/usr/lib/swift \
+                        -Xcxx -I/usr/lib/swift/Block
 
             -   name: Test SymbolGraphBuilder
                 run: |
-                    swift run -c release SymbolGraphBuilderTests
+                    swift run -c release \
+                        -Xcxx -I/usr/lib/swift \
+                        -Xcxx -I/usr/lib/swift/Block \
+                        SymbolGraphBuilderTests

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "0c04c8df0571a4795562655875b6a18b9c74a5e3ac13781dbd39f81c6b122a5d",
+  "originHash" : "11a2c92dc12e2d1090f389f23c98adcb98ad3e0b6ccf1e724d65aeb0152c5554",
   "pins" : [
-    {
-      "identity" : "indexstore-db",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/indexstore-db",
-      "state" : {
-        "branch" : "swift-5.10-RELEASE",
-        "revision" : "89ec16c2ac1bb271614e734a2ee792224809eb20"
-      }
-    },
     {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "25883f12cf4eb759ed4a7b02bac9272cad664cd8aabefb3cc5928b2793c7845f",
+  "originHash" : "0c04c8df0571a4795562655875b6a18b9c74a5e3ac13781dbd39f81c6b122a5d",
   "pins" : [
+    {
+      "identity" : "indexstore-db",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/indexstore-db",
+      "state" : {
+        "branch" : "swift-5.10-RELEASE",
+        "revision" : "89ec16c2ac1bb271614e734a2ee792224809eb20"
+      }
+    },
     {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -296,6 +296,7 @@ let package:Package = .init(
                 .target(name: "MarkdownABI"),
                 .target(name: "Signatures"),
                 .target(name: "Snippets"),
+                .target(name: "Sources"),
                 .target(name: "Symbols"),
 
                 .product(name: "SwiftIDEUtils", package: "swift-syntax"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
 // swift-tools-version:5.10
+import class Foundation.ProcessInfo
 import PackageDescription
 import CompilerPluginSupport
 
 let package:Package = .init(
-    name: "swift-unidoc",
+    name: "Swift Unidoc",
     platforms: [.macOS(.v14)],
     products: [
         .executable(name: "ssgc", targets: ["ssgc"]),
@@ -101,9 +102,6 @@ let package:Package = .init(
 
         .package(url: "https://github.com/tayloraswift/swift-png", .upToNextMinor(
             from: "4.4.2")),
-
-        .package(url: "https://github.com/apple/indexstore-db",
-            branch: "swift-5.10-RELEASE"),
 
         .package(url: "https://github.com/apple/swift-atomics", .upToNextMinor(
             from: "1.2.0")),
@@ -301,12 +299,6 @@ let package:Package = .init(
 
                 .product(name: "SwiftIDEUtils", package: "swift-syntax"),
                 .product(name: "SwiftParser", package: "swift-syntax"),
-            ]),
-
-        .target(name: "MarkdownPluginSwift_IndexStoreDB",
-            dependencies: [
-                .target(name: "MarkdownPluginSwift"),
-                .product(name: "IndexStoreDB", package: "indexstore-db"),
             ]),
 
         .target(name: "MarkdownSemantics",
@@ -756,6 +748,25 @@ let package:Package = .init(
 
         .target(name: "guides", path: "Guides"),
     ])
+
+switch ProcessInfo.processInfo.environment["UNIDOC_ENABLE_INDEXSTORE"]?.lowercased()
+{
+case "1"?, "true"?:
+    package.dependencies.append(.package(url: "https://github.com/apple/indexstore-db",
+        branch: "swift-5.10-RELEASE"))
+
+    package.targets.append(.target(name: "MarkdownPluginSwift_IndexStoreDB",
+        dependencies: [
+            .target(name: "MarkdownPluginSwift"),
+            .product(name: "IndexStoreDB", package: "indexstore-db"),
+        ]))
+
+default:
+    package.targets.append(.target(name: "MarkdownPluginSwift_IndexStoreDB",
+        dependencies: [
+            .target(name: "MarkdownPluginSwift"),
+        ]))
+}
 
 for target:PackageDescription.Target in package.targets
 {

--- a/Package.swift
+++ b/Package.swift
@@ -102,8 +102,8 @@ let package:Package = .init(
         .package(url: "https://github.com/tayloraswift/swift-png", .upToNextMinor(
             from: "4.4.2")),
 
-        // .package(url: "https://github.com/apple/indexstore-db",
-        //     branch: "swift-5.10-RELEASE"),
+        .package(url: "https://github.com/apple/indexstore-db",
+            branch: "swift-5.10-RELEASE"),
 
         .package(url: "https://github.com/apple/swift-atomics", .upToNextMinor(
             from: "1.2.0")),
@@ -305,7 +305,7 @@ let package:Package = .init(
         .target(name: "MarkdownPluginSwift_IndexStoreDB",
             dependencies: [
                 .target(name: "MarkdownPluginSwift"),
-                // .product(name: "IndexStoreDB", package: "indexstore-db"),
+                .product(name: "IndexStoreDB", package: "indexstore-db"),
             ]),
 
         .target(name: "MarkdownSemantics",

--- a/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexMarker.swift
+++ b/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexMarker.swift
@@ -1,4 +1,5 @@
 import Symbols
+import Sources
 
 extension Markdown.SwiftLanguage
 {
@@ -6,13 +7,16 @@ extension Markdown.SwiftLanguage
     struct IndexMarker
     {
         public
+        let position:SourcePosition
+        public
         let symbol:Symbol.USR
         public
         let phylum:Phylum.Decl?
 
         @inlinable public
-        init(symbol:Symbol.USR, phylum:Phylum.Decl?)
+        init(position:SourcePosition, symbol:Symbol.USR, phylum:Phylum.Decl?)
         {
+            self.position = position
             self.symbol = symbol
             self.phylum = phylum
         }
@@ -23,6 +27,6 @@ extension Markdown.SwiftLanguage.IndexMarker:CustomStringConvertible
     public
     var description:String
     {
-        "(\(self.phylum?.name ?? "unknown"): \(self.symbol))"
+        "(\(self.position): \(self.symbol), \(self.phylum?.name ?? "unknown"))"
     }
 }

--- a/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexMarker.swift
+++ b/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexMarker.swift
@@ -1,0 +1,20 @@
+import Symbols
+
+extension Markdown.SwiftLanguage
+{
+    @frozen public
+    struct IndexMarker
+    {
+        public
+        let symbol:Symbol.USR
+        public
+        let phylum:Phylum.Decl?
+
+        @inlinable public
+        init(symbol:Symbol.USR, phylum:Phylum.Decl?)
+        {
+            self.symbol = symbol
+            self.phylum = phylum
+        }
+    }
+}

--- a/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexMarker.swift
+++ b/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexMarker.swift
@@ -18,3 +18,11 @@ extension Markdown.SwiftLanguage
         }
     }
 }
+extension Markdown.SwiftLanguage.IndexMarker:CustomStringConvertible
+{
+    public
+    var description:String
+    {
+        "(\(self.phylum?.name ?? "unknown"): \(self.symbol))"
+    }
+}

--- a/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexStore.swift
+++ b/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.IndexStore.swift
@@ -3,6 +3,7 @@ extension Markdown.SwiftLanguage
     public
     protocol IndexStore:AnyObject
     {
-        func load(for path:String)
+        /// Returns a list of index markers, indexed by UTF-8 offset.
+        func load(for path:String, utf8:[UInt8]) -> [Int: IndexMarker]
     }
 }

--- a/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.swift
+++ b/Sources/MarkdownPluginSwift/Markdown.SwiftLanguage.swift
@@ -34,9 +34,16 @@ extension Markdown.SwiftLanguage
     func parse(snippet utf8:[UInt8],
         from indexID:String? = nil) -> (caption:String, slices:[Markdown.SnippetSlice])
     {
-        if  let indexID:String
+        let links:[Int: IndexMarker]
+
+        if  let indexID:String,
+            let index:any IndexStore = self.index
         {
-            self.index?.load(for: indexID)
+            links = index.load(for: indexID, utf8: utf8)
+        }
+        else
+        {
+            links = [:]
         }
 
         //  It is safe to escape the pointer to ``Parser.parse(source:maximumNestingLevel:)``,
@@ -98,7 +105,7 @@ extension Markdown.SwiftLanguage
         }
 
         let slices:[SnippetParser.Slice] = parser.finish(at: parsed.endPosition, in: utf8)
-        var cursor:SyntaxClassificationCursor = .init(parsed.classifications)
+        var cursor:SyntaxClassificationCursor = .init(parsed.classifications, links: links)
 
         let rendered:[Markdown.SnippetSlice] = slices.map
         {

--- a/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.SpanIterator.swift
+++ b/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.SpanIterator.swift
@@ -58,6 +58,8 @@ extension SyntaxClassificationCursor.SpanIterator
             case .protocol:         highlight.kind = .type
             case .struct:           highlight.kind = .type
             case .typealias:        highlight.kind = .type
+            case .func:             highlight.kind = .identifier
+            case .initializer:      highlight.kind = .keyword
             default:                break
             }
         }

--- a/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.SpanIterator.swift
+++ b/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.SpanIterator.swift
@@ -1,0 +1,51 @@
+import SwiftIDEUtils
+import Symbols
+
+extension SyntaxClassificationCursor
+{
+    struct SpanIterator
+    {
+        private
+        var links:[Int: Markdown.SwiftLanguage.IndexMarker]
+        private
+        var spans:Array<SyntaxClassifiedRange>.Iterator
+
+        init(_ spans:consuming SyntaxClassifications,
+            links:[Int: Markdown.SwiftLanguage.IndexMarker] = [:])
+        {
+            self.links = links
+            self.spans = spans.makeIterator()
+        }
+    }
+}
+extension SyntaxClassificationCursor.SpanIterator
+{
+    mutating
+    func next() -> SyntaxClassifiedRange?
+    {
+        guard
+        var highlight:SyntaxClassifiedRange = self.spans.next()
+        else
+        {
+            return nil
+        }
+
+        if  let marker:Markdown.SwiftLanguage.IndexMarker = self.links[highlight.offset],
+            let phylum:Phylum.Decl = marker.phylum
+        {
+            switch phylum
+            {
+            case .actor:            highlight.kind = .type
+            case .associatedtype:   highlight.kind = .type
+            case .class:            highlight.kind = .type
+            case .enum:             highlight.kind = .type
+            case .protocol:         highlight.kind = .type
+            case .struct:           highlight.kind = .type
+            case .typealias:        highlight.kind = .type
+            default:                break
+            }
+        }
+
+        return highlight
+    }
+}

--- a/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.SpanIterator.swift
+++ b/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.SpanIterator.swift
@@ -18,6 +18,22 @@ extension SyntaxClassificationCursor
         }
     }
 }
+extension SyntaxClassificationCursor.SpanIterator:CustomDebugStringConvertible
+{
+    var debugDescription:String
+    {
+        self.links
+            .sorted
+        {
+            $0.key < $1.key
+        }
+            .map
+        {
+            "[\($0.key)]: \($0.value)"
+        }
+            .joined(separator: "\n")
+    }
+}
 extension SyntaxClassificationCursor.SpanIterator
 {
     mutating

--- a/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.swift
+++ b/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.swift
@@ -3,7 +3,9 @@ import SwiftSyntax
 
 struct SyntaxClassificationCursor
 {
+    private(set)
     var spans:SpanIterator
+    private
     var span:SyntaxClassifiedRange?
 
     init(_ spans:consuming SyntaxClassifications,

--- a/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.swift
+++ b/Sources/MarkdownPluginSwift/SyntaxClassificationCursor.swift
@@ -3,12 +3,13 @@ import SwiftSyntax
 
 struct SyntaxClassificationCursor
 {
-    var spans:SyntaxClassifications.Iterator
+    var spans:SpanIterator
     var span:SyntaxClassifiedRange?
 
-    init(_ spans:consuming SyntaxClassifications)
+    init(_ spans:consuming SyntaxClassifications,
+        links:[Int: Markdown.SwiftLanguage.IndexMarker] = [:])
     {
-        self.spans = spans.makeIterator()
+        self.spans = .init(spans, links: links)
         self.span = self.spans.next()
     }
 

--- a/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
+++ b/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
@@ -2,6 +2,7 @@
 
 import class IndexStoreDB.IndexStoreDB
 import MarkdownPluginSwift
+import Sources
 import Symbols
 
 extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
@@ -28,6 +29,8 @@ extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
                 roles: .all)
             {
                 guard
+                let position:SourcePosition = .init(line: occurence.location.line - 1,
+                    column: occurence.location.utf8Column - 1),
                 let base:Int = lines[occurence.location.line],
                 let usr:Symbol.USR = .init(symbol.usr)
                 else
@@ -70,7 +73,8 @@ extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
                 case .commentTag:           phylum = nil
                 }
 
-                markers[base + occurence.location.utf8Column - 1] = .init(symbol: usr,
+                markers[base + occurence.location.utf8Column - 1] = .init(position: position,
+                    symbol: usr,
                     phylum: phylum)
             }
         }

--- a/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
+++ b/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
@@ -1,20 +1,81 @@
 #if canImport(IndexStoreDB)
 
-import IndexStoreDB
+import class IndexStoreDB.IndexStoreDB
 import MarkdownPluginSwift
+import Symbols
 
 extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
 {
     public
-    func load(for id:String)
+    func load(for id:String, utf8:[UInt8]) -> [Int: Markdown.SwiftLanguage.IndexMarker]
     {
-        for symbol:Symbol in self.symbols(inFilePath: id)
+        //  Compute line positions
+        var lines:[Int: Int] = [1: utf8.startIndex]
+        var line:Int = 1
+        for (i, byte):(Int, UInt8) in zip(utf8.indices, utf8)
         {
-            for occurence:SymbolOccurrence in self.occurrences(ofUSR: symbol.usr, roles: .all)
+            if  byte == 0x0A
             {
-                print(occurence)
+                line += 1
+                lines[line] = i
             }
         }
+
+        var markers:[Int: Markdown.SwiftLanguage.IndexMarker] = [:]
+        for symbol:IndexStoreDB.Symbol_ in self.symbols(inFilePath: id)
+        {
+            for occurence:IndexStoreDB.SymbolOccurrence_ in self.occurrences(ofUSR: symbol.usr,
+                roles: .all)
+            {
+                guard
+                let base:Int = lines[occurence.location.line],
+                let usr:Symbol.USR = .init(symbol.usr)
+                else
+                {
+                    continue
+                }
+
+                let phylum:Phylum.Decl?
+
+                switch symbol.kind
+                {
+                case .unknown:              phylum = nil
+                case .module:               phylum = nil
+                case .namespace:            phylum = nil
+                case .namespaceAlias:       phylum = nil
+                case .macro:                phylum = nil
+                case .enum:                 phylum = .enum
+                case .struct:               phylum = .struct
+                case .class:                phylum = .class
+                case .protocol:             phylum = .protocol
+                case .extension:            phylum = .typealias
+                case .union:                phylum = .enum
+                case .typealias:            phylum = .typealias
+                case .function:             phylum = .func(nil)
+                case .variable:             phylum = .var(nil)
+                case .field:                phylum = nil
+                case .enumConstant:         phylum = .case
+                case .instanceMethod:       phylum = .func(.instance)
+                case .classMethod:          phylum = .func(.class)
+                case .staticMethod:         phylum = .func(.static)
+                case .instanceProperty:     phylum = .var(.instance)
+                case .classProperty:        phylum = .var(.class)
+                case .staticProperty:       phylum = .var(.static)
+                case .constructor:          phylum = .initializer
+                case .destructor:           phylum = .deinitializer
+                case .conversionFunction:   phylum = nil
+                case .parameter:            phylum = nil
+                case .using:                phylum = nil
+                case .concept:              phylum = nil
+                case .commentTag:           phylum = nil
+                }
+
+                markers[base + occurence.location.utf8Column] = .init(symbol: usr,
+                    phylum: phylum)
+            }
+        }
+
+        return markers
     }
 }
 

--- a/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
+++ b/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
@@ -42,6 +42,11 @@ extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
 
                 switch symbol.kind
                 {
+                case .constructor:
+                    phylum = occurence.roles.contains(.call)
+                        ? .func(.static)
+                        : .initializer
+
                 case .unknown:              phylum = nil
                 case .module:               phylum = nil
                 case .namespace:            phylum = nil

--- a/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
+++ b/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
@@ -69,7 +69,6 @@ extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
                 case .instanceProperty:     phylum = .var(.instance)
                 case .classProperty:        phylum = .var(.class)
                 case .staticProperty:       phylum = .var(.static)
-                case .constructor:          phylum = .initializer
                 case .destructor:           phylum = .deinitializer
                 case .conversionFunction:   phylum = nil
                 case .parameter:            phylum = nil

--- a/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
+++ b/Sources/MarkdownPluginSwift_IndexStoreDB/IndexStoreDB (ext).swift
@@ -17,7 +17,7 @@ extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
             if  byte == 0x0A
             {
                 line += 1
-                lines[line] = i
+                lines[line] = utf8.index(after: i)
             }
         }
 
@@ -70,7 +70,7 @@ extension IndexStoreDB:Markdown.SwiftLanguage.IndexStore
                 case .commentTag:           phylum = nil
                 }
 
-                markers[base + occurence.location.utf8Column] = .init(symbol: usr,
+                markers[base + occurence.location.utf8Column - 1] = .init(symbol: usr,
                     phylum: phylum)
             }
         }

--- a/Sources/MarkdownPluginSwift_IndexStoreDB/shims.swift
+++ b/Sources/MarkdownPluginSwift_IndexStoreDB/shims.swift
@@ -1,0 +1,11 @@
+#if canImport(IndexStoreDB)
+
+import IndexStoreDB
+
+extension IndexStoreDB
+{
+    typealias Symbol_ = Symbol
+    typealias SymbolOccurrence_ = SymbolOccurrence
+}
+
+#endif

--- a/Sources/Symbols/Declarations/Phylum.Decl.swift
+++ b/Sources/Symbols/Declarations/Phylum.Decl.swift
@@ -158,3 +158,37 @@ extension Phylum.Decl:RawRepresentable
         }
     }
 }
+extension Phylum.Decl
+{
+    @inlinable public
+    var name:String
+    {
+        switch self
+        {
+        case .actor:                "actor"
+        case .associatedtype:       "associatedtype"
+        case .case:                 "case"
+        case .class:                "class"
+        case .deinitializer:        "deinitializer"
+        case .enum:                 "enum"
+        case .func(nil):            "global func"
+        case .func(.instance):      "func"
+        case .func(.class):         "class func"
+        case .func(.static):        "static func"
+        case .initializer:          "init"
+        case .macro(.attached):     "attached macro"
+        case .macro(.freestanding): "freestanding macro"
+        case .operator:             "operator"
+        case .protocol:             "protocol"
+        case .struct:               "struct"
+        case .subscript(.static):   "static subscript"
+        case .subscript(.class):    "class subscript"
+        case .subscript(.instance): "subscript"
+        case .typealias:            "typealias"
+        case .var(nil):             "global var"
+        case .var(.instance):       "var"
+        case .var(.class):          "class var"
+        case .var(.static):         "static var"
+        }
+    }
+}

--- a/TestPackages/swift-snippets/Package.swift
+++ b/TestPackages/swift-snippets/Package.swift
@@ -4,7 +4,9 @@ import PackageDescription
 let package:Package = .init(name: "Swift Unidoc Snippets Test Package",
     products:
     [
+        .library(name: "Snippets", targets: ["Snippets"]),
     ],
     targets:
     [
+        .target(name: "Snippets", dependencies: []),
     ])

--- a/TestPackages/swift-snippets/Snippets/Snippet.swift
+++ b/TestPackages/swift-snippets/Snippets/Snippet.swift
@@ -1,12 +1,16 @@
+import Snippets
+
 enum Enum
 {
     case a(Int)
+    case b(CustomType)
 }
 extension Enum
 {
     init()
     {
         let a = Int.init(1)
+        let b = CustomType.init()
         self = .a(a)
     }
 }

--- a/TestPackages/swift-snippets/Snippets/Snippet.swift
+++ b/TestPackages/swift-snippets/Snippets/Snippet.swift
@@ -2,3 +2,6 @@ enum E
 {
     case a
 }
+extension E
+{
+}

--- a/TestPackages/swift-snippets/Snippets/Snippet.swift
+++ b/TestPackages/swift-snippets/Snippets/Snippet.swift
@@ -1,7 +1,18 @@
 enum E
 {
-    case a
+    case a(Int)
 }
 extension E
 {
+    init()
+    {
+        let a = Int.init(1)
+        self = .a(a)
+    }
+}
+
+func f()
+{
+    let e = E()
+    print(e)
 }

--- a/TestPackages/swift-snippets/Snippets/Snippet.swift
+++ b/TestPackages/swift-snippets/Snippets/Snippet.swift
@@ -1,8 +1,8 @@
-enum E
+enum Enum
 {
     case a(Int)
 }
-extension E
+extension Enum
 {
     init()
     {
@@ -11,8 +11,17 @@ extension E
     }
 }
 
+struct `init`
+{
+    init()
+    {
+    }
+}
+
 func f()
 {
-    let e = E()
-    print(e)
+    let _ = `init`()
+    let _ = Enum()
+    let _:Enum = Enum.init()
+    let _:Enum = .init()
 }

--- a/TestPackages/swift-snippets/Sources/Snippets/CustomType.swift
+++ b/TestPackages/swift-snippets/Sources/Snippets/CustomType.swift
@@ -1,0 +1,6 @@
+public
+struct CustomType
+{
+    public
+    init() {}
+}

--- a/TestPackages/swift-snippets/Sources/Snippets/Snippets.md
+++ b/TestPackages/swift-snippets/Sources/Snippets/Snippets.md
@@ -1,0 +1,5 @@
+# Snippets test
+
+This is a snippet highlighting test.
+
+@Snippet(id: "Snippet")


### PR DESCRIPTION
this PR adds most of the logic needed for improved IndexStoreDB syntax highlighting, gated behind the build-time `UNIDOC_ENABLE_INDEXSTORE=1` environment variable.

this violates our longstanding ban on the Foundation dependency, but all the alternatives seemed patently stupid. (and it’s not like importing Foundation in the *manifest* could cause any problems in the first place.)

for unknown reasons, our IndexStoreDB intergration is unable to emit symbol information for symbols outside the current SwiftPM Snippet, which is our principal use case. so the feature will be of very little impact until that issue is resolved. that issue will be tracked in #246 