### PR TITLE
unclog docs feed

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -537,6 +537,7 @@ let package:Package = .init(
                 .target(name: "Media"),
                 .target(name: "UnidocAssets"),
                 .target(name: "UnidocRecords"),
+                .target(name: "UnixTime"),
 
                 .product(name: "HTML", package: "swift-dom"),
             ]),

--- a/Sources/UnidocAPI/Status/Unidoc.SitemapDelta.swift
+++ b/Sources/UnidocAPI/Status/Unidoc.SitemapDelta.swift
@@ -6,10 +6,10 @@ extension Unidoc
         public
         let deletions:[Shoot]
         public
-        let additions:Int
+        let additions:[Shoot]
 
         @inlinable public
-        init(deletions:[Shoot], additions:Int)
+        init(deletions:[Shoot], additions:[Shoot])
         {
             self.deletions = deletions
             self.additions = additions
@@ -19,5 +19,5 @@ extension Unidoc
 extension Unidoc.SitemapDelta
 {
     @inlinable public static
-    var zero:Self { .init(deletions: [], additions: 0) }
+    var zero:Self { .init(deletions: [], additions: []) }
 }

--- a/Sources/UnidocAPI/Status/Unidoc.SurfaceDelta.swift
+++ b/Sources/UnidocAPI/Status/Unidoc.SurfaceDelta.swift
@@ -1,0 +1,19 @@
+extension Unidoc
+{
+    @frozen public
+    enum SurfaceDelta:Equatable, Sendable
+    {
+        /// The uplink introduces a brand new API surface; no release documentation had
+        /// previously been published for the associated package.
+        case initial
+        /// The uplink did not affect any publicly-relevant package or volume. For example, the
+        /// package may be hidden, or the uplink might have been for a historical version.
+        case ignored
+        /// The uplink changed the API surface of an **existing release version** of an existing
+        /// package. It should be extremely rare for the payload to be non-nil.
+        case changed(SitemapDelta?)
+        /// The uplink changed the API surface of an existing package by replacing it with the
+        /// API surface of a **new release version**.
+        case updated(SitemapDelta?)
+    }
+}

--- a/Sources/UnidocAPI/Status/Unidoc.UplinkStatus.swift
+++ b/Sources/UnidocAPI/Status/Unidoc.UplinkStatus.swift
@@ -12,13 +12,13 @@ extension Unidoc
         public
         let hidden:Bool
         public
-        let delta:SitemapDelta?
+        let delta:SurfaceDelta?
 
         @inlinable public
         init(edition:Edition,
             volume:Symbol.Volume,
             hidden:Bool,
-            delta:SitemapDelta?)
+            delta:SurfaceDelta?)
         {
             self.edition = edition
             self.volume = volume

--- a/Sources/UnidocServer/Plugins/Unidoc.GraphLinker.Event.swift
+++ b/Sources/UnidocServer/Plugins/Unidoc.GraphLinker.Event.swift
@@ -36,34 +36,62 @@ extension Unidoc.GraphLinker.Event:HTML.OutputStreamable
                 $0[.dd] = uplinked.hidden ? "yes" : "no"
 
                 guard
-                let delta:Unidoc.SitemapDelta = uplinked.delta
+                let delta:Unidoc.SurfaceDelta = uplinked.delta
                 else
                 {
                     return
                 }
 
-                $0[.dt] = "Additions"
-                $0[.dd] = "\(delta.additions)"
+                $0[.dt] = "Delta"
 
-                if  delta.deletions.isEmpty
+                let api:Unidoc.SitemapDelta?
+
+                switch delta
+                {
+                case .initial:
+                    $0[.dd] = "Initial"
+                    return
+
+                case .ignored:
+                    $0[.dd] = "Ignored"
+                    return
+
+                case .changed(let delta):
+                    $0[.dd] = "Changed"
+                    api = delta
+
+                case .updated(let delta):
+                    $0[.dd] = "Updated"
+                    api = delta
+                }
+
+                guard
+                let api:Unidoc.SitemapDelta
+                else
                 {
                     return
                 }
 
-                $0[.dt] = "Deletions"
-                $0[.dd]
+                for (list, name):([Unidoc.Shoot], String) in [
+                    (api.deletions, "Deletions"),
+                    (api.additions, "Additions")
+                ]   where !list.isEmpty
                 {
-                    $0[.ol]
+                    $0[.dt] = name
+                    $0[.dd]
                     {
-                        for shoot:Unidoc.Shoot in delta.deletions
+                        $0[.ol]
                         {
-                            if  let hash:FNV24 = shoot.hash
+                            for shoot:Unidoc.Shoot in list
                             {
-                                $0[.li] = "\(shoot.stem) [\(hash)]"
-                            }
-                            else
-                            {
-                                $0[.li] = "\(shoot.stem)"
+                                if  let hash:FNV24 = shoot.hash
+                                {
+                                    $0[.li] = "\(shoot.stem) [\(hash)]"
+                                }
+                                else
+                                {
+                                    $0[.li] = "\(shoot.stem)"
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
we basically stopped publishing docs events for the past 2.5 months, because we don’t have good defenses against update spam. so this PR adds the logic we need to start selectively publishing docs events again.