### PR TITLE
allow disabling HTTPS in local development mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
                 run: |
                     timeout 60s bash -c \
                     'until docker exec -t unidoc-mongod-container \
-                    /bin/mongosh --file /unidoc-rs-init.js; do sleep 1; done'
+                    /bin/mongosh --file /unidoc-rs-init-containerized.js; do sleep 1; done'
 
             -   name: Run pipeline
                 run: |

--- a/Guides/docs.docc/Quickstart.md
+++ b/Guides/docs.docc/Quickstart.md
@@ -71,13 +71,22 @@ Once you have a `unidoc-mongod-container` running in the background, you can sta
 
 ### Generating certificates
 
+#### Unidoc < 0.17.0
+
 If you are starting the server for the first time, you likely need to populate the `Assets/certificates/` directory with TLS certificates. See <doc:GeneratingCertificates> for instructions on how to do this.
 
+#### Unidoc ≥ 0.17.0
 
-If you did all of these steps correctly, you should be able to navigate to [`localhost:8443/`](https://localhost:8443/) and view a blank homepage.
+You do not need to generate certificates, as Unidoc 0.17.0 can run locally in insecure mode.
 
 
 ## Populating a local documentation server
+
+If you did all of the previous steps correctly, you should be able to navigate to [`localhost:8080/`](http://localhost:8080/) and view a blank homepage.
+
+>   Note:
+>   If you are using HTTPS, you need to replace the scheme with `https://` and the port number with `8443`.
+
 
 A fresh Unidoc database contains no documentation. Let’s build some now.
 
@@ -102,7 +111,7 @@ Uploading symbol graph...
 Successfully uploaded symbol graph!
 ```
 
-Because you built these docs “abnormally” (meaning: not from a GitHub repository), they won’t show up in the homepage, but you can view them by navigating directly to [`localhost:8443/docs/swift`](https://localhost:8443/docs/swift).
+Because you built these docs “abnormally” (meaning: not from a GitHub repository), they won’t show up in the homepage, but you can view them by navigating directly to [`localhost:8080/docs/swift`](http://localhost:8080/docs/swift).
 
 >   Note:
     You may see a lot of compiler errors when building the standard library. This is expected, as the documentation for the standard library contains many errors.
@@ -125,7 +134,7 @@ Next, you can try building `swift-nio` with `unidoc-build`, specifying the path 
 
 @Code(file: load-swift-nio.sh, title: load-swift-nio.sh)
 
-Unidoc will launch a `swift build` process, which could take a few minutes to build the package. When the build completes, it will then compile, upload, and link the documentation. Because the documentation is local, it will have the version number `__max`, and it will not show up on the homepage. You can view it by navigating directly to [`localhost:8443/docs/swift-nio`](https://localhost:8443/docs/swift-nio).
+Unidoc will launch a `swift build` process, which could take a few minutes to build the package. When the build completes, it will then compile, upload, and link the documentation. Because the documentation is local, it will have the version number `__max`, and it will not show up on the homepage. You can view it by navigating directly to [`localhost:8080/docs/swift-nio`](http://localhost:8080/docs/swift-nio).
 
 Congratulations! You have successfully set up a local Unidoc server and previewed some documentation for a local project.
 

--- a/Guides/docs.docc/Quickstart.md
+++ b/Guides/docs.docc/Quickstart.md
@@ -138,6 +138,9 @@ Unidoc will launch a `swift build` process, which could take a few minutes to bu
 
 Congratulations! You have successfully set up a local Unidoc server and previewed some documentation for a local project.
 
+>   Warning: 
+>   At the time of writing, there is a [Swift compiler bug](https://github.com/swiftlang/swift/issues/68767) that prevents `swift symbolgraph-extract` from emitting symbol data for Swift NIO on macOS. 
+
 
 ## Differences between DocC and Unidoc
 

--- a/Guides/docs.docc/local/docker-compose.yml
+++ b/Guides/docs.docc/local/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         volumes:
             # cannot put this in docker-entrypoint-initdb.d, it does not work
             - ./unidoc-rs-init.js:/unidoc-rs-init.js
+            - ./unidoc-rs-init-containerized.js:/unidoc-rs-init-containerized.js
             - ./unidoc-rs.conf:/etc/mongod.conf
             - ../../../.mongod:/data/db
         command: mongod --config /etc/mongod.conf

--- a/Sources/GitHubClient/GitHub.Client.Connection.swift
+++ b/Sources/GitHubClient/GitHub.Client.Connection.swift
@@ -58,12 +58,7 @@ extension GitHub.Client<GitHub.PersonalAccessToken>.Connection
         switch response.status
         {
         case 200?:
-            var json:JSON = .init(utf8: [])
-            for buffer:ByteBuffer in response.buffers
-            {
-                json.utf8 += buffer.readableBytesView
-            }
-
+            let json:JSON = .init(utf8: response.body[...])
             return try json.decode()
 
         case 403?:
@@ -127,12 +122,7 @@ extension GitHub.Client.Connection
             switch response.status
             {
             case 200?:
-                var json:JSON = .init(utf8: [])
-                for buffer:ByteBuffer in response.buffers
-                {
-                    json.utf8 += buffer.readableBytesView
-                }
-
+                let json:JSON = .init(utf8: response.body[...])
                 return try json.decode()
 
             case 301?:

--- a/Sources/GitHubClient/GitHub.Client.swift
+++ b/Sources/GitHubClient/GitHub.Client.swift
@@ -134,14 +134,9 @@ extension GitHub.Client
             throw AuthenticationError.status(.init(code: status))
         }
 
-        var json:JSON = .init(utf8: [])
-        for buffer:ByteBuffer in response.buffers
-        {
-            json.utf8 += buffer.readableBytesView
-        }
-
         do
         {
+            let json:JSON = .init(utf8: response.body[...])
             return try json.decode()
         }
         catch let error

--- a/Sources/HTTPClient/HTTP.Client.swift
+++ b/Sources/HTTPClient/HTTP.Client.swift
@@ -1,0 +1,19 @@
+extension HTTP
+{
+    public
+    protocol Client:Identifiable, Sendable
+    {
+        associatedtype Connection:ClientConnection
+
+        /// Connect to the ``remote`` host and perform the given operation.
+        func connect<T>(port:Int, with body:(Connection) async throws -> T) async throws -> T
+
+        var remote:String { get }
+    }
+}
+extension HTTP.Client
+{
+    /// Returns the ``remote`` hostname.
+    @inlinable public
+    var id:String { self.remote }
+}

--- a/Sources/HTTPClient/HTTP.ClientConnection.swift
+++ b/Sources/HTTPClient/HTTP.ClientConnection.swift
@@ -1,0 +1,33 @@
+import NIOCore
+
+extension HTTP
+{
+    public
+    protocol ClientConnection
+    {
+        func buffer(string:Substring) -> ByteBuffer
+        func buffer(bytes:ArraySlice<UInt8>) -> ByteBuffer
+
+        var remote:String { get }
+    }
+}
+extension HTTP.ClientConnection
+{
+    @inlinable public
+    func buffer(string:String) -> ByteBuffer
+    {
+        /// In Swift >= 5.3, this has negligible performance penalty.
+        self.buffer(string: string[...])
+    }
+
+    @inlinable public
+    func buffer(_ body:HTTP.Resource.Content.Body) -> ByteBuffer
+    {
+        switch body
+        {
+        case .buffer(let buffer):   buffer
+        case .binary(let bytes):    self.buffer(bytes: bytes)
+        case .string(let string):   self.buffer(string: string)
+        }
+    }
+}

--- a/Sources/HTTPClient/HTTP1/HTTP.Client1.Connection.swift
+++ b/Sources/HTTPClient/HTTP1/HTTP.Client1.Connection.swift
@@ -6,13 +6,17 @@ extension HTTP.Client1
     @frozen public
     struct Connection
     {
-        @usableFromInline internal
+        @usableFromInline
         let channel:any Channel
+        /// The hostname of the remote peer.
+        public
+        let remote:String
 
-        @inlinable internal
-        init(channel:any Channel)
+        @inlinable
+        init(channel:any Channel, remote:String)
         {
             self.channel = channel
+            self.remote = remote
         }
     }
 }
@@ -22,17 +26,18 @@ extension HTTP.Client1
 extension HTTP.Client1.Connection:Sendable
 {
 }
-extension HTTP.Client1.Connection
+extension HTTP.Client1.Connection:HTTP.ClientConnection
 {
     @inlinable public
-    func buffer(_ body:HTTP.Resource.Content.Body) -> ByteBuffer
+    func buffer(string:Substring) -> ByteBuffer
     {
-        switch body
-        {
-        case .buffer(let buffer):   buffer
-        case .binary(let bytes):    self.channel.allocator.buffer(bytes: bytes)
-        case .string(let string):   self.channel.allocator.buffer(string: string)
-        }
+        self.channel.allocator.buffer(substring: string)
+    }
+
+    @inlinable public
+    func buffer(bytes:ArraySlice<UInt8>) -> ByteBuffer
+    {
+        self.channel.allocator.buffer(bytes: bytes)
     }
 }
 extension HTTP.Client1.Connection

--- a/Sources/HTTPClient/HTTP1/HTTP.Client1.Facet.swift
+++ b/Sources/HTTPClient/HTTP1/HTTP.Client1.Facet.swift
@@ -6,7 +6,7 @@ extension HTTP.Client1
     @frozen public
     struct Facet:Sendable
     {
-        public
+        @usableFromInline
         var head:HTTPResponseHead?
         public
         var body:[UInt8]
@@ -17,4 +17,12 @@ extension HTTP.Client1
             self.body = body
         }
     }
+}
+extension HTTP.Client1.Facet
+{
+    @inlinable public
+    var headers:HTTPHeaders? { self.head?.headers }
+
+    @inlinable public
+    var status:UInt? { self.head?.status.code }
 }

--- a/Sources/HTTPClient/HTTP2/HTTP.Client2.Connection.swift
+++ b/Sources/HTTPClient/HTTP2/HTTP.Client2.Connection.swift
@@ -29,18 +29,12 @@ extension HTTP.Client2
 extension HTTP.Client2.Connection:Sendable
 {
 }
-extension HTTP.Client2.Connection
+extension HTTP.Client2.Connection:HTTP.ClientConnection
 {
     @inlinable public
     func buffer(string:Substring) -> ByteBuffer
     {
         self.channel.allocator.buffer(substring: string)
-    }
-
-    @inlinable public
-    func buffer(string:String) -> ByteBuffer
-    {
-        self.channel.allocator.buffer(string: string)
     }
 
     @inlinable public

--- a/Sources/HTTPClient/HTTP2/HTTP.Client2.Facet.swift
+++ b/Sources/HTTPClient/HTTP2/HTTP.Client2.Facet.swift
@@ -10,12 +10,12 @@ extension HTTP.Client2
         public
         var headers:HPACKHeaders?
         public
-        var buffers:[ByteBuffer]
+        var body:[UInt8]
 
-        init(headers:HPACKHeaders? = nil, buffers:[ByteBuffer] = [])
+        init(headers:HPACKHeaders? = nil, body:[UInt8] = [])
         {
             self.headers = headers
-            self.buffers = buffers
+            self.body = body
         }
     }
 }
@@ -54,7 +54,7 @@ extension HTTP.Client2.Facet
         case .data(let frame):
             if  case .byteBuffer(let buffer) = frame.data
             {
-                self.buffers.append(buffer)
+                buffer.withUnsafeReadableBytes { self.body += $0 }
                 return frame.endStream
             }
 

--- a/Sources/HTTPClient/HTTP2/HTTP.Client2.swift
+++ b/Sources/HTTPClient/HTTP2/HTTP.Client2.swift
@@ -30,12 +30,6 @@ extension HTTP
         }
     }
 }
-extension HTTP.Client2:Identifiable
-{
-    /// Returns the ``remote`` hostname.
-    @inlinable public
-    var id:String { self.remote }
-}
 extension HTTP.Client2
 {
     public
@@ -94,7 +88,7 @@ extension HTTP.Client2
         try await self.connect { try await $0.fetch(request) }
     }
 }
-extension HTTP.Client2
+extension HTTP.Client2:HTTP.Client
 {
     /// Connect to the remote host over HTTPS and perform the given operation.
     @inlinable public

--- a/Sources/HTTPServer/AsyncThrowingChannel (ext).swift
+++ b/Sources/HTTPServer/AsyncThrowingChannel (ext).swift
@@ -1,0 +1,42 @@
+import _AsyncChannel
+import NIOCore
+import NIOHTTP1
+
+extension AsyncThrowingChannel<HTTPPart<HTTPRequestHead, ByteBuffer>, any Error>.Iterator
+{
+    /// Accumulates buffers from the channel insecurely, returning nil if the accumulated
+    /// data does not match the expected length. This should not be used in production modes.
+    mutating
+    func accumulateBuffers(length:Int) async throws -> [UInt8]?
+    {
+        var body:[UInt8]
+        if  length == 0
+        {
+            return []
+        }
+        else
+        {
+            body = []
+            body.reserveCapacity(length)
+        }
+
+        while case .body(let buffer)? = try await self.next()
+        {
+            if  buffer.readableBytes <= length - body.count
+            {
+                buffer.withUnsafeReadableBytes { body += $0 }
+            }
+            else
+            {
+                return nil
+            }
+
+            if  buffer.readableBytes == length
+            {
+                return body
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/HTTPServer/AsyncThrowingChannel (ext).swift
+++ b/Sources/HTTPServer/AsyncThrowingChannel (ext).swift
@@ -31,7 +31,7 @@ extension AsyncThrowingChannel<HTTPPart<HTTPRequestHead, ByteBuffer>, any Error>
                 return nil
             }
 
-            if  buffer.readableBytes == length
+            if  length == body.count
             {
                 return body
             }

--- a/Sources/HTTPServer/HTTP.Server.swift
+++ b/Sources/HTTPServer/HTTP.Server.swift
@@ -327,7 +327,7 @@ extension HTTP.Server
         guard let path:URI = .init(h1.uri)
         else
         {
-            return .resource("Malformed URI", status: 400)
+            return .resource("Malformed URI\n", status: 400)
         }
 
         switch h1.method
@@ -344,8 +344,38 @@ extension HTTP.Server
             }
             else
             {
-                return .resource("Malformed request", status: 400)
+                return .resource("Malformed request\n", status: 400)
             }
+
+        case .PUT:
+            guard
+            let length:String = h1.headers["content-length"].first,
+            let length:Int = .init(length)
+            else
+            {
+                return .resource("Content length required\n", status: 411)
+            }
+
+            guard
+            let request:StreamedRequest = .init(put: path, headers: h1.headers)
+            else
+            {
+                return .resource("Malformed request\n", status: 400)
+            }
+
+            if  let failure:HTTP.ServerResponse = try await self.clearance(for: request)
+            {
+                return failure
+            }
+
+            guard
+            let body:[UInt8] = try await inbound.accumulateBuffers(length: length)
+            else
+            {
+                return .resource("Content length does not match payload\n", status: 413)
+            }
+
+            return try await self.response(for: request, with: body)
 
         case .POST:
             guard
@@ -353,35 +383,19 @@ extension HTTP.Server
             let length:Int = .init(length)
             else
             {
-                return .resource("Content length required", status: 411)
+                return .resource("Content length required\n", status: 411)
             }
 
             if  length > 1_000_000
             {
-                return .resource("Content too large", status: 413)
+                return .resource("Content too large\n", status: 413)
             }
 
-            var body:[UInt8] = []
-            if  length > 0
+            guard
+            let body:[UInt8] = try await inbound.accumulateBuffers(length: length)
+            else
             {
-                body.reserveCapacity(length)
-
-                while case .body(let buffer)? = try await inbound.next()
-                {
-                    if  buffer.readableBytes <= length - body.count
-                    {
-                        buffer.withUnsafeReadableBytes { body += $0 }
-                    }
-                    else
-                    {
-                        return .resource("Content too large", status: 413)
-                    }
-
-                    if  buffer.readableBytes == length
-                    {
-                        break
-                    }
-                }
+                return .resource("Content length does not match payload\n", status: 400)
             }
 
             if  let request:IntegralRequest = .init(post: path,
@@ -393,11 +407,11 @@ extension HTTP.Server
             }
             else
             {
-                return .resource("Malformed request", status: 400)
+                return .resource("Malformed request\n", status: 400)
             }
 
         default:
-            return .resource("Method requires HTTP/2", status: 505)
+            return .resource("Method requires HTTP/2\n", status: 505)
         }
     }
 }
@@ -618,8 +632,7 @@ extension HTTP.Server
             }
 
             guard
-            let request:StreamedRequest = .init(put: path,
-                headers: headers)
+            let request:StreamedRequest = .init(put: path, headers: headers)
             else
             {
                 return .resource("Malformed request", status: 400)

--- a/Sources/HTTPServer/HTTP.Server.swift
+++ b/Sources/HTTPServer/HTTP.Server.swift
@@ -691,8 +691,15 @@ extension HTTP.Server
 
                 while let payload:HTTP2Frame.FramePayload? = try await inbound.next()
                 {
+                    guard 
+                    let payload:HTTP2Frame.FramePayload 
+                    else 
+                    {
+                        return .resource("Time limit exceeded", status: 408)
+                    }
+
                     guard
-                    case .data(let payload)? = payload,
+                    case .data(let payload) = payload,
                     case .byteBuffer(let buffer) = payload.data
                     else
                     {

--- a/Sources/S3Client/AWS.S3.Client.swift
+++ b/Sources/S3Client/AWS.S3.Client.swift
@@ -44,7 +44,7 @@ extension AWS.S3.Client
     @inlinable public
     func connect<T>(with body:(AWS.S3.Connection) async throws -> T) async throws -> T
     {
-        try await self.http1.connect
+        try await self.http1.connect(port: 443)
         {
             try await body(AWS.S3.Connection.init(bucket: self.bucket, http1: $0))
         }

--- a/Sources/S3Client/AWS.S3.Connection.swift
+++ b/Sources/S3Client/AWS.S3.Connection.swift
@@ -67,13 +67,13 @@ extension AWS.S3.Connection
                 body: body),
             timeout: timeout)
 
-        switch response.head?.status
+        switch response.status
         {
-        case .ok?:
+        case 200?:
             return
 
         case let status:
-            throw AWS.S3.RequestError.put(status?.code ?? 0, String.init(
+            throw AWS.S3.RequestError.put(status ?? 0, String.init(
                 decoding: response.body,
                 as: Unicode.UTF8.self))
         }
@@ -88,13 +88,13 @@ extension AWS.S3.Connection
                 head: ["host": bucket.domain]),
             timeout: timeout)
 
-        switch response.head?.status
+        switch response.status
         {
-        case .ok?:
+        case 200?:
             return response.body
 
         case let status:
-            throw AWS.S3.RequestError.get(status?.code ?? 0, String.init(
+            throw AWS.S3.RequestError.get(status ?? 0, String.init(
                 decoding: response.body,
                 as: Unicode.UTF8.self))
         }
@@ -109,16 +109,16 @@ extension AWS.S3.Connection
                 head: ["host": bucket.domain]),
             timeout: .seconds(15))
 
-        switch response.head?.status
+        switch response.status
         {
-        case .ok?, .noContent?:
+        case 200?, 204?:
             return true
 
-        case .notFound?:
+        case 404?:
             return false
 
         case let status:
-            throw AWS.S3.RequestError.delete(status?.code ?? 0, String.init(
+            throw AWS.S3.RequestError.delete(status ?? 0, String.init(
                 decoding: response.body,
                 as: Unicode.UTF8.self))
         }

--- a/Sources/SymbolGraphs/Metadata/SymbolGraphMetadata.Commit.swift
+++ b/Sources/SymbolGraphs/Metadata/SymbolGraphMetadata.Commit.swift
@@ -6,11 +6,14 @@ extension SymbolGraphMetadata
     struct Commit:Equatable, Sendable
     {
         /// The git ref used to check out the original package sources, if the
-        /// relevant symbol graph was generated for a source-controlled SPM package.
+        /// relevant symbol graph was generated for a source-controlled SwiftPM package.
         /// This is an **exact** string; `v1.2.3` and  `1.2.3` are not equivalent.
         ///
-        /// It’s possible for multiple commits to have the same refname. This is typical for
+        /// It’s possible for multiple commits to have the same ref name. This is typical for
         /// branches.
+        /// 
+        /// It’s also possible for a commit to have multiple ref names. The name stored here 
+        /// is whatever SwiftPM used to check out the sources.
         public
         var name:String
         /// The SHA-1 hash of the commit, nil if unknown. If the hash is unknown, the refname

--- a/Sources/UnidocServer/HTTP.Client2.Connection (ext).swift
+++ b/Sources/UnidocServer/HTTP.Client2.Connection (ext).swift
@@ -28,11 +28,7 @@ extension HTTP.Client2.Connection
         switch response.status
         {
         case 200?:
-            var json:JSON = .init(utf8: [])
-            for buffer:ByteBuffer in response.buffers
-            {
-                buffer.withUnsafeReadableBytes { json.utf8 += $0 }
-            }
+            let json:JSON = .init(utf8: response.body[...])
             return try json.decode()
 
         case let code:

--- a/Sources/unidoc-build/Unidoc.Build.swift
+++ b/Sources/unidoc-build/Unidoc.Build.swift
@@ -186,7 +186,7 @@ extension Unidoc.Build
     private
     func requests() async throws
     {
-        let unidoc:Unidoc.Client = try .init(from: self)
+        let unidoc:Unidoc.Client<HTTP.Client2> = try .init(from: self)
         let cache:FilePath = "swiftpm"
 
         while true
@@ -235,8 +235,6 @@ extension Unidoc.Build
     private
     func local() async throws
     {
-        let unidoc:Unidoc.Client = try .init(from: self)
-
         guard
         let project:Symbol.Package = self.project
         else
@@ -244,15 +242,25 @@ extension Unidoc.Build
             fatalError("No project specified")
         }
 
-        try await unidoc.buildAndUpload(local: project,
-            search: self.input.map(FilePath.init(_:)),
-            type: self.book ? .book : .package)
+        let search:FilePath? = self.input.map(FilePath.init(_:))
+        let type:SSGC.ProjectType = self.book ? .book : .package
+
+        if  case nil = self.authorization
+        {
+            let unidoc:Unidoc.Client<HTTP.Client1> = try .init(from: self)
+            try await unidoc.buildAndUpload(local: project, search: search, type: type)
+        }
+        else
+        {
+            let unidoc:Unidoc.Client<HTTP.Client2> = try .init(from: self)
+            try await unidoc.buildAndUpload(local: project, search: search, type: type)
+        }
     }
 
     private
     func latest() async throws
     {
-        let unidoc:Unidoc.Client = try .init(from: self)
+        let unidoc:Unidoc.Client<HTTP.Client2> = try .init(from: self)
 
         guard
         let project:Symbol.Package = self.project

--- a/Sources/unidoc-build/Unidoc.Build.swift
+++ b/Sources/unidoc-build/Unidoc.Build.swift
@@ -39,7 +39,7 @@ extension Unidoc
             self.authorization = nil
             self.project = nil
             self.host = "localhost"
-            self.port = 8443
+            self.port = 8080
 
             self.pretty = false
             self.book = false
@@ -116,6 +116,7 @@ extension Unidoc.Build
             {
             case "--authorization", "-i":
                 options.authorization = try arguments.next(for: option)
+                options.port = 8443
 
             case "--swiftinit", "-S":
                 options.host = "swiftinit.org"

--- a/Sources/unidoc-preview/Unidoc.Preview.swift
+++ b/Sources/unidoc-preview/Unidoc.Preview.swift
@@ -26,7 +26,7 @@ extension Unidoc
             self.development.port = 8080
             self.mirror = false
             self.https = false
-            self.mongo = "unidoc-mongod"
+            self.mongo = "localhost"
         }
     }
 }

--- a/Sources/unidoc-preview/Unidoc.Preview.swift
+++ b/Sources/unidoc-preview/Unidoc.Preview.swift
@@ -23,8 +23,9 @@ extension Unidoc
         {
             self.certificates = "Assets/certificates"
             self.development = .init()
+            self.development.port = 8080
             self.mirror = false
-            self.https = true
+            self.https = false
             self.mongo = "unidoc-mongod"
         }
     }
@@ -49,9 +50,9 @@ extension Unidoc.Preview
             case "-s", "--replica-set":
                 self.development.replicaSet = try arguments.next(for: "replica-set")
 
-            case "--http":
-                self.https = false
-                self.development.port = 8080
+            case "-e", "--https":
+                self.https = true
+                self.development.port = 8443
 
             case "-m", "--mongo":
                 self.mongo = .init(try arguments.next(for: "mongo"))


### PR DESCRIPTION
the server is optimized for HTTP/2 over TLS, so performance over HTTP/1.1 with no TLS might not be as great as we expect. but that’s probably fine for local dev mode, and means we won’t need to generate local certificates to use `unidoc-preview`

this PR makes the insecure mode the default for `unidoc-preview` and the `unidoc-build local` subcommand.