### PR TITLE
support previewing documentation for multiple local packages at once

### DIFF
--- a/Sources/UnidocDB/Snapshots/Unidoc.PinDependenciesQuery.swift
+++ b/Sources/UnidocDB/Snapshots/Unidoc.PinDependenciesQuery.swift
@@ -9,7 +9,7 @@ extension Unidoc
 {
     struct PinDependenciesQuery:Sendable
     {
-        private
+        private(set)
         var patches:[Symbol.PackageDependency<PatchVersion>]
 
         private
@@ -21,13 +21,22 @@ extension Unidoc
 }
 extension Unidoc.PinDependenciesQuery
 {
-    init?(for snapshot:borrowing Unidoc.Snapshot)
+    init?(for snapshot:borrowing Unidoc.Snapshot, locally local:Bool)
     {
         self.init()
 
+        /// To link against versioned documentation, a snapshot must itself be versioned!
+        let localOverride:PatchVersion? = local ? .max : nil
+
         for case (nil, let dependency) in zip(snapshot.pins, snapshot.metadata.dependencies)
         {
-            if  let version:PatchVersion = dependency.version.release
+            if  let localOverride:PatchVersion
+            {
+                let exonym:Symbol.Package = dependency.package.name
+                self.patches.append(.init(package: exonym, version: localOverride))
+            }
+            else if
+                let version:PatchVersion = dependency.version.release
             {
                 self.patches.append(.init(package: dependency.id, version: version))
             }

--- a/Sources/UnidocDB/Unidoc.DB.swift
+++ b/Sources/UnidocDB/Unidoc.DB.swift
@@ -371,7 +371,7 @@ extension Unidoc.DB
                 sha1: commit.sha1,
                 with: session)
         }
-        else if 
+        else if
             case .swift = documentation.metadata.package.name,
             case nil = documentation.metadata.swift.nightly
         {
@@ -665,8 +665,10 @@ extension Unidoc.DB
             snapshot.pins += repeatElement(nil, count: unallocated)
         }
 
+        let local:Bool = snapshot.metadata.commit == nil
+
         guard
-        let query:Unidoc.PinDependenciesQuery = .init(for: snapshot)
+        let query:Unidoc.PinDependenciesQuery = .init(for: snapshot, locally: local)
         else
         {
             return
@@ -687,7 +689,9 @@ extension Unidoc.DB
             snapshot.pins.indices,
             snapshot.metadata.dependencies)
         {
-            if  let pinned:Unidoc.Edition = pins[dependency.id]
+            if  let pinned:Unidoc.Edition = local
+                    ? pins[dependency.package.name]
+                    : pins[dependency.id]
             {
                 snapshot.pins[pin] = pinned
                 all.append(pinned)
@@ -776,12 +780,12 @@ extension Unidoc.DB
 
             version = "\(semver.number)"
         }
-        else if 
+        else if
             case .swift = snapshot.metadata.package.name,
             case nil = snapshot.metadata.swift.nightly
         {
-            //  The default Xcode toolchain on macOS has a version, but no associated 
-            //  tags in the `swiftlang/swift` repo, so if we didn’t have this carve-out, 
+            //  The default Xcode toolchain on macOS has a version, but no associated
+            //  tags in the `swiftlang/swift` repo, so if we didn’t have this carve-out,
             //  we would always consider it local.
             if  let formerRelease:Volumes.PatchView = try await self.volumes.latestRelease(
                     of: snapshot.id.package,


### PR DESCRIPTION
this PR adds support for previewing documentation for multiple packages locally at once, by enabling local docs (`__local:__max`) to link against other docs with the same special version (`__local:__max`).

when running Unidoc in multi-package mode, the database admin is responsible for ensuring that all symbol graphs in the database were generated from the same version of the dependency that the root package was built with. therefore, it is strongly recommended to use separate databases for build trees that depend on different versions of the same package, as the entire database is considered a single build tree for the purposes of symbol linking.

in addition, the database admin is responsible for resolving all package name collisions between packages in the database. (repo names must be unique.) linking documentation against an incompatible symbol graph will result in undefined behavior!