### PR TITLE
sunday scaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+# This workflow builds the project under the “starter” configuration, namely, what you would get
+# if you ran `swift build` without any arguments. We use this to verify that we can generate the
+# documentation for Unidoc itself.
+
+name: build
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    linux:
+        runs-on: ubuntu-22.04
+        name: Ubuntu 22.04
+        env:
+            UNIDOC_ENABLE_INDEXSTORE: "0"
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Build debug
+                run: |
+                    swift --version
+                    swift build
+
+    macos:
+        runs-on: macos-14
+        name: macOS
+        env:
+            UNIDOC_ENABLE_INDEXSTORE: "0"
+            DEVELOPER_DIR: "/Applications/Xcode_15.3.app/Contents/Developer"
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v3
+
+            -   name: Build debug
+                run: |
+                    swift --version
+                    swift build
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# This workflow builds the project for production, with IndexStoreDB integration enabled.
+
 name: ci
 
 on:

--- a/Sources/SymbolGraphBuilderTests/Main.SnippetHighlightingTest.ExpectedFragment.swift
+++ b/Sources/SymbolGraphBuilderTests/Main.SnippetHighlightingTest.ExpectedFragment.swift
@@ -1,3 +1,5 @@
+#if canImport(IndexStoreDB)
+
 import MarkdownABI
 import Symbols
 
@@ -20,3 +22,5 @@ extension Main.SnippetHighlightingTest
         }
     }
 }
+
+#endif

--- a/Sources/SymbolGraphBuilderTests/Main.swift
+++ b/Sources/SymbolGraphBuilderTests/Main.swift
@@ -1,6 +1,7 @@
 import BSON
 import HTML
 import MarkdownPluginSwift
+import MarkdownRendering
 @_spi(testable)
 import SymbolGraphBuilder
 import SymbolGraphs


### PR DESCRIPTION
resolve build failure when `UNIDOC_ENABLE_INDEXSTORE=0`, so that we can publish Unidoc’s own documentation once more