### PR TITLE
Cache stdlib

### DIFF
--- a/Sources/SymbolGraphBuilder/Artifacts/SSGC.SymbolCache.swift
+++ b/Sources/SymbolGraphBuilder/Artifacts/SSGC.SymbolCache.swift
@@ -31,13 +31,13 @@ extension SSGC.SymbolCache
         as language:Phylum.Language) throws -> SSGC.SymbolCulture?
     {
         guard
-        var parts:[SymbolGraphPart.ID] = self.symbols.modules[module]
+        var files:SSGC.SymbolFiles = self.symbols.modules[module]
         else
         {
             return nil
         }
 
-        parts.removeAll
+        files.parts.removeAll
         {
             if  let colony:Symbol.Module = $0.colony, !filter.isEmpty
             {
@@ -49,19 +49,19 @@ extension SSGC.SymbolCache
             }
         }
 
-        if  parts.isEmpty
+        if  files.parts.isEmpty
         {
             return nil
         }
 
-        parts.sort { $0.basename < $1.basename }
+        files.parts.sort { $0.basename < $1.basename }
 
-        let dumps:[SSGC.SymbolDump] = try parts.map
+        let dumps:[SSGC.SymbolDump] = try files.parts.map
         {
             (id:SymbolGraphPart.ID) in try
             {
                 let symbols:SSGC.SymbolDump = try $0 ?? .init(loading: id,
-                    from: self.symbols.location,
+                    from: files.location,
                     base: base)
 
                 $0 = symbols

--- a/Sources/SymbolGraphBuilder/Artifacts/SSGC.SymbolDumps.swift
+++ b/Sources/SymbolGraphBuilder/Artifacts/SSGC.SymbolDumps.swift
@@ -7,13 +7,11 @@ extension SSGC
     @_spi(testable) public
     struct SymbolDumps
     {
-        let location:FilePath.Directory
-        let modules:[Symbol.Module: [SymbolGraphPart.ID]]
+        let modules:[Symbol.Module: SymbolFiles]
 
         private
-        init(location:FilePath.Directory, modules:[Symbol.Module: [SymbolGraphPart.ID]])
+        init(modules:[Symbol.Module: SymbolFiles])
         {
-            self.location = location
             self.modules = modules
         }
     }
@@ -21,47 +19,56 @@ extension SSGC
 extension SSGC.SymbolDumps
 {
     @_spi(testable) public
-    static func collect(from location:FilePath.Directory) throws -> Self
+    static func collect(from locations:FilePath.Directory...) throws -> Self
     {
-        let symbols:[Symbol.Module: [SymbolGraphPart.ID]] = try location.reduce(
+        try .collect(from: locations)
+    }
+
+    static func collect(from locations:[FilePath.Directory]) throws -> Self
+    {
+        let symbols:[Symbol.Module: SSGC.SymbolFiles] = try locations.reduce(
             into: [:])
         {
-            //  We don’t want to *parse* the JSON yet to discover the culture,
-            //  because the JSON can be very large, and parsing JSON is very
-            //  expensive (compared to parsing BSON). So we trust that the file
-            //  name is correct and indicates what is contained within the file.
-            let filename:FilePath.Component = try $1.get()
-            guard
-            let id:SymbolGraphPart.ID = .init("\(filename)")
-            else
+            for filename:Result<FilePath.Component, any Error> in $1
             {
-                return
-            }
+                //  We don’t want to *parse* the JSON yet to discover the culture,
+                //  because the JSON can be very large, and parsing JSON is very
+                //  expensive (compared to parsing BSON). So we trust that the file
+                //  name is correct and indicates what is contained within the file.
+                let filename:FilePath.Component = try filename.get()
 
-            switch id.namespace
-            {
-            case    "CDispatch",                    // too low-level
-                    "CFURLSessionInterface",        // too low-level
-                    "CFXMLInterface",               // too low-level
-                    "CoreFoundation",               // too low-level
-                    "Glibc",                        // linux-gnu specific
-                    "SwiftGlibc",                   // linux-gnu specific
-                    "SwiftOnoneSupport",            // contains no symbols
-                    "SwiftOverlayShims",            // too low-level
-                    "SwiftShims",                   // contains no symbols
-                    "_Builtin_intrinsics",          // contains only one symbol, free(_:)
-                    "_Builtin_stddef_max_align_t",  // contains only two symbols
-                    "_InternalStaticMirror",        // unbuildable
-                    "_InternalSwiftScan",           // unbuildable
-                    "_SwiftConcurrencyShims",       // contains only two symbols
-                    "std":                          // unbuildable
-                return
+                guard
+                let id:SymbolGraphPart.ID = .init("\(filename)")
+                else
+                {
+                    continue
+                }
 
-            default:
-                $0[id.culture, default: []].append(id)
+                switch id.namespace
+                {
+                case    "CDispatch",                    // too low-level
+                        "CFURLSessionInterface",        // too low-level
+                        "CFXMLInterface",               // too low-level
+                        "CoreFoundation",               // too low-level
+                        "Glibc",                        // linux-gnu specific
+                        "SwiftGlibc",                   // linux-gnu specific
+                        "SwiftOnoneSupport",            // contains no symbols
+                        "SwiftOverlayShims",            // too low-level
+                        "SwiftShims",                   // contains no symbols
+                        "_Builtin_intrinsics",          // contains only one symbol, free(_:)
+                        "_Builtin_stddef_max_align_t",  // contains only two symbols
+                        "_InternalStaticMirror",        // unbuildable
+                        "_InternalSwiftScan",           // unbuildable
+                        "_SwiftConcurrencyShims",       // contains only two symbols
+                        "std":                          // unbuildable
+                    continue
+
+                default:
+                    $0[id.culture, default: .init(location: $1)].parts.append(id)
+                }
             }
         }
 
-        return .init(location: location, modules: symbols)
+        return .init(modules: symbols)
     }
 }

--- a/Sources/SymbolGraphBuilder/Artifacts/SSGC.SymbolFiles.swift
+++ b/Sources/SymbolGraphBuilder/Artifacts/SSGC.SymbolFiles.swift
@@ -1,0 +1,17 @@
+import SymbolGraphParts
+import System
+
+extension SSGC
+{
+    struct SymbolFiles
+    {
+        let location:FilePath.Directory
+        var parts:[SymbolGraphPart.ID]
+
+        init(location:FilePath.Directory, parts:[SymbolGraphPart.ID] = [])
+        {
+            self.location = location
+            self.parts = parts
+        }
+    }
+}

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.DocumentationBuild.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.DocumentationBuild.swift
@@ -7,7 +7,7 @@ extension SSGC
     {
         mutating
         func compile(updating status:SSGC.StatusStream?,
-            into artifacts:FilePath.Directory,
+            cache:FilePath.Directory,
             with swift:Toolchain,
             clean:Bool) throws -> (SymbolGraphMetadata, any DocumentationSources)
     }

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
@@ -14,6 +14,8 @@ extension SSGC
         /// What is being built.
         let id:ID
 
+        let scratch:PackageBuildDirectory
+
         /// Additional flags to pass to the Swift compiler.
         var flags:Flags
 
@@ -22,9 +24,14 @@ extension SSGC
         let type:ProjectType
 
         private
-        init(id:ID, flags:Flags, root:FilePath.Directory, type:ProjectType)
+        init(id:ID,
+            scratch:PackageBuildDirectory,
+            flags:Flags,
+            root:FilePath.Directory,
+            type:ProjectType)
         {
             self.id = id
+            self.scratch = scratch
             self.flags = flags
             self.root = root
             self.type = type
@@ -33,6 +40,7 @@ extension SSGC
 }
 extension SSGC.PackageBuild
 {
+    private
     func listExtraManifests() throws -> [MinorVersion]
     {
         var versions:[MinorVersion] = []
@@ -57,6 +65,36 @@ extension SSGC.PackageBuild
 
         return versions
     }
+
+    private
+    func modulesToDump(
+        among modules:SSGC.ModuleGraph) throws -> [(Symbol.Module, [FilePath.Directory])]
+    {
+        var modulesToDump:[Symbol.Module: [FilePath.Directory]] = [:]
+        for module:SSGC.ModuleLayout in modules.sinkLayout.cultures
+        {
+            let constituents:[SSGC.ModuleLayout] = try modules.constituents(of: module)
+            let include:[FilePath.Directory] = constituents.reduce(into: [self.scratch.include])
+            {
+                $0 += $1.include
+            }
+            for constituent:SSGC.ModuleLayout in constituents
+            {
+                //  The Swift compiler won’t generate these automatically, so we need to extract
+                //  the symbols manually.
+                switch constituent.language
+                {
+                case .c?:   break
+                case .cpp?: break
+                default:    continue
+                }
+
+                modulesToDump[constituent.id] = include
+            }
+        }
+
+        return modulesToDump.sorted { $0.key < $1.key }
+    }
 }
 extension SSGC.PackageBuild
 {
@@ -74,15 +112,21 @@ extension SSGC.PackageBuild
     ///     -   flags:
     ///         Additional flags to pass to the Swift compiler.
     public static
-    func local(project name:Symbol.Package,
+    func local(
+        project projectName:Symbol.Package,
         among projects:FilePath.Directory,
+        using scratchName:FilePath.Component = ".build.ssgc",
         as type:SSGC.ProjectType = .package,
         flags:Flags = .init()) -> Self
     {
-        let project:FilePath.Directory = projects / "\(name)"
+        let project:FilePath.Directory = projects / "\(projectName)"
+        let scratch:SSGC.PackageBuildDirectory = .init(configuration: .debug,
+            location: project / scratchName)
+
         if  project.path.isAbsolute
         {
-            return .init(id: .unversioned(name),
+            return .init(id: .unversioned(projectName),
+                scratch: scratch,
                 flags: flags,
                 root: project,
                 type: type)
@@ -90,7 +134,8 @@ extension SSGC.PackageBuild
         else if
             let current:FilePath.Directory = .current()
         {
-            return .init(id: .unversioned(name),
+            return .init(id: .unversioned(projectName),
+                scratch: scratch,
                 flags: flags,
                 root: .init(path: current.path.appending(project.path.components)),
                 type: type)
@@ -118,7 +163,7 @@ extension SSGC.PackageBuild
     ///     -   workspace:
     ///         The directory in which this function will create folders.
     public static
-    func remote(project name:Symbol.Package,
+    func remote(project projectName:Symbol.Package,
         from repository:String,
         at reference:String,
         as type:SSGC.ProjectType = .package,
@@ -126,19 +171,26 @@ extension SSGC.PackageBuild
         flags:Flags = .init(),
         clean:Bool = false) throws -> Self
     {
-        let checkout:SSGC.Checkout = try .checkout(project: name,
+        let checkout:SSGC.Checkout = try .checkout(project: projectName,
             from: repository,
             at: reference,
             in: workspace,
             clean: clean)
 
+        /// This is a far less-common use case than the local one, so we don’t support
+        /// customizing the scratch directory name.
+        let scratchName:FilePath.Component = ".build.ssgc"
+        let scratch:SSGC.PackageBuildDirectory = .init(configuration: .debug,
+            location: checkout.location / scratchName)
+
         let version:AnyVersion = .init(reference)
-        let pin:SPM.DependencyPin = .init(identity: name,
+        let pin:SPM.DependencyPin = .init(identity: projectName,
             location: .remote(url: repository),
             revision: checkout.revision,
             version: version)
 
         return .init(id: .versioned(pin, reference: reference),
+            scratch: scratch,
             flags: flags,
             root: checkout.location,
             type: type)
@@ -148,7 +200,7 @@ extension SSGC.PackageBuild
 extension SSGC.PackageBuild:SSGC.DocumentationBuild
 {
     func compile(updating status:SSGC.StatusStream?,
-        into artifacts:FilePath.Directory,
+        cache:FilePath.Directory,
         with swift:SSGC.Toolchain,
         clean:Bool = true) throws -> (SymbolGraphMetadata, any SSGC.DocumentationSources)
     {
@@ -156,13 +208,13 @@ extension SSGC.PackageBuild:SSGC.DocumentationBuild
         {
         case .package:
             try self.compileSwiftPM(updating: status,
-                into: artifacts,
+                cache: cache,
                 with: swift,
                 clean: clean)
 
         case .book:
             try self.compileBook(updating: status,
-                into: artifacts,
+                cache: cache,
                 with: swift)
         }
     }
@@ -172,7 +224,7 @@ extension SSGC.PackageBuild
 {
     @_spi(testable) public
     func compileBook(updating status:SSGC.StatusStream? = nil,
-        into artifacts:FilePath.Directory,
+        cache _:FilePath.Directory,
         with swift:SSGC.Toolchain) throws -> (SymbolGraphMetadata, SSGC.BookSources)
     {
         switch self.id
@@ -201,7 +253,7 @@ extension SSGC.PackageBuild
                 name: self.id.package),
             commit: self.id.commit,
             triple: swift.triple,
-            swift: swift.version,
+            swift: swift.id,
             tools: nil,
             manifests: [],
             requirements: [],
@@ -215,10 +267,19 @@ extension SSGC.PackageBuild
 
     @_spi(testable) public
     func compileSwiftPM(updating status:SSGC.StatusStream? = nil,
-        into artifacts:FilePath.Directory,
+        cache:FilePath.Directory,
         with swift:SSGC.Toolchain,
         clean:Bool = true) throws -> (SymbolGraphMetadata, SSGC.PackageSources)
     {
+        if  clean
+        {
+            try self.scratch.location.remove()
+        }
+        /// Note that the Swift compiler already uses a subdirectory named `artifacts`, so we
+        /// name ours `ssgc` to avoid conflicts
+        let artifacts:FilePath.Directory = self.scratch.location / "ssgc"
+        try artifacts.create(clean: false)
+
         switch self.id
         {
         case .unversioned(let package):
@@ -250,29 +311,26 @@ extension SSGC.PackageBuild
 
         try status?.send(.didResolveDependencies)
 
-        let scratch:SSGC.PackageBuildDirectory
         do
         {
-            scratch = try swift.build(package: self.root, flags: self.flags.dumping(
-                    symbols: .default,
-                    to: artifacts),
-                clean: clean)
+            try swift.build(package: self.root,
+                using: self.scratch,
+                flags: self.flags.dumping(symbols: .default, to: artifacts))
         }
         catch SystemProcessError.exit(let code, let invocation)
         {
             throw SSGC.PackageBuildError.swift_build(code, invocation)
         }
 
-        var packages:SSGC.PackageGraph = .init(platform: try swift.platform())
+        let platform:SymbolGraphMetadata.Platform = try swift.platform()
+        var packages:SSGC.PackageGraph = .init(platform: platform)
 
-        //  Dump the standard library’s symbols
-        let standardLibrary:SSGC.StandardLibrary = .init(platform: try swift.platform())
         for pin:SPM.DependencyPin in pins
         {
             print("Dumping manifest for package '\(pin.identity)' at \(pin.state)")
 
             let manifest:SPM.Manifest = try swift.manifest(
-                package: scratch.location / "checkouts" / "\(pin.location.name)",
+                package: self.scratch.location / "checkouts" / "\(pin.location.name)",
                 json: artifacts / "\(pin.identity).package.json",
                 leaf: false)
 
@@ -283,40 +341,21 @@ extension SSGC.PackageBuild
             with: &manifest,
             as: self.id.package)
 
-        var modulesToDump:[Symbol.Module: [FilePath.Directory]] = [:]
-        for module:SymbolGraph.Module in standardLibrary.modules
-        {
-            modulesToDump[module.id] = []
-        }
-        for module:SSGC.ModuleLayout in modules.sinkLayout.cultures
-        {
-            let constituents:[SSGC.ModuleLayout] = try modules.constituents(of: module)
-            let include:[FilePath.Directory] = constituents.reduce(into: [scratch.include])
-            {
-                $0 += $1.include
-            }
-            for constituent:SSGC.ModuleLayout in constituents
-            {
-                //  The Swift compiler won’t generate these automatically, so we need to extract
-                //  the symbols manually.
-                switch constituent.language
-                {
-                case .c?:   break
-                case .cpp?: break
-                default:    continue
-                }
-
-                modulesToDump[constituent.id] = include
-            }
-        }
-        for (module, include):(Symbol.Module, [FilePath.Directory]) in modulesToDump.sorted(
-            by: { $0.key < $1.key })
+        //  Dump the standard library’s symbols, unless they’re already cached.
+        let artifactsCached:FilePath.Directory = try swift.dump(
+            standardLibrary: .init(platform: platform),
+            options: .default,
+            cache: cache)
+        for (module, include):(Symbol.Module, [FilePath.Directory]) in try self.modulesToDump(
+            among: modules)
         {
             try swift.dump(module: module, to: artifacts, options: .default, include: include)
         }
 
         //  This step is considered part of documentation building.
-        var sources:SSGC.PackageSources = .init(scratch: scratch, modules: modules)
+        var sources:SSGC.PackageSources = .init(scratch: self.scratch,
+            symbols: [artifacts, artifactsCached],
+            modules: modules)
         do
         {
             let snippetsDirectory:FilePath.Component
@@ -343,17 +382,13 @@ extension SSGC.PackageBuild
             throw SSGC.DocumentationBuildError.scanning(error)
         }
 
-        //  try swift.dump(modules: sources.cultures.lazy.map(\.module),
-        //      to: artifacts,
-        //      include: include)
-
         let metadata:SymbolGraphMetadata = .init(
             package: .init(
                 scope: self.id.pin?.location.owner,
                 name: self.id.package),
             commit: self.id.commit,
             triple: swift.triple,
-            swift: swift.version,
+            swift: swift.id,
             tools: manifest.format,
             manifests: manifestVersions,
             requirements: manifest.requirements,

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
@@ -119,31 +119,18 @@ extension SSGC.PackageBuild
         as type:SSGC.ProjectType = .package,
         flags:Flags = .init()) -> Self
     {
+        /// The projects path could be absolute or relative. If it’s relative, we need to
+        /// convert it to an absolute path.
+        let projects:FilePath.Directory = projects.absolute()
         let project:FilePath.Directory = projects / "\(projectName)"
         let scratch:SSGC.PackageBuildDirectory = .init(configuration: .debug,
             location: project / scratchName)
 
-        if  project.path.isAbsolute
-        {
-            return .init(id: .unversioned(projectName),
-                scratch: scratch,
-                flags: flags,
-                root: project,
-                type: type)
-        }
-        else if
-            let current:FilePath.Directory = .current()
-        {
-            return .init(id: .unversioned(projectName),
-                scratch: scratch,
-                flags: flags,
-                root: .init(path: current.path.appending(project.path.components)),
-                type: type)
-        }
-        else
-        {
-            fatalError("Couldn’t determine the current working directory.")
-        }
+        return .init(id: .unversioned(projectName),
+            scratch: scratch,
+            flags: flags,
+            root: project,
+            type: type)
     }
 
     /// Clones or pulls the specified package from a git repository, checking out

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuildDirectory.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuildDirectory.swift
@@ -10,6 +10,15 @@ extension SSGC
 
         init(configuration:PackageBuildConfiguration, location:FilePath.Directory)
         {
+            guard location.path.isAbsolute
+            else
+            {
+                fatalError("""
+                    Package build directory must be an absolute path,
+                    for IndexStoreDB compatibility!
+                    """)
+            }
+
             self.configuration = configuration
             self.location = location
         }

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
@@ -22,7 +22,7 @@ extension SSGC
 extension SSGC.Workspace
 {
     @inlinable public
-    var artifacts:FilePath.Directory { self.location / "artifacts" }
+    var cache:FilePath.Directory { self.location / "cache" }
     @inlinable public
     var checkouts:FilePath.Directory { self.location / "checkouts" }
 }
@@ -56,7 +56,7 @@ extension SSGC.Workspace
     func create(at location:FilePath.Directory) throws -> Self
     {
         let workspace:Self = .init(location: location)
-        try workspace.artifacts.create()
+        try workspace.cache.create()
         try workspace.checkouts.create()
         return workspace
     }
@@ -91,15 +91,15 @@ extension SSGC.Workspace
         let metadata:SymbolGraphMetadata
         let package:any SSGC.DocumentationSources
 
-        let artifacts:FilePath.Directory = self.artifacts
-        try artifacts.create(clean: clean)
+        let cache:FilePath.Directory = self.cache
+        try cache.create(clean: clean)
 
         (metadata, package) = try build.compile(updating: status,
-            into: artifacts,
+            cache: cache,
             with: swift,
             clean: clean)
 
-        let documentation:SymbolGraph = try package.link(symbols: try .collect(from: artifacts),
+        let documentation:SymbolGraph = try package.link(
             logger: logger,
             with: swift)
 

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
@@ -31,19 +31,7 @@ extension SSGC.Workspace
     private
     init(location:FilePath.Directory)
     {
-        if  location.path.isAbsolute
-        {
-            self.init(absolute: location)
-        }
-        else if
-            let current:FilePath.Directory = .current()
-        {
-            self.init(absolute: .init(path: current.path.appending(location.path.components)))
-        }
-        else
-        {
-            fatalError("Couldn’t determine the current working directory.")
-        }
+        self.init(absolute: location.absolute())
     }
 
     public static

--- a/Sources/SymbolGraphBuilder/FilePath (ext).swift
+++ b/Sources/SymbolGraphBuilder/FilePath (ext).swift
@@ -1,0 +1,21 @@
+import System
+
+extension FilePath
+{
+    func absolute() -> Self
+    {
+        if  self.isAbsolute
+        {
+            return self
+        }
+        else if
+            let current:FilePath.Directory = .current()
+        {
+            return current.path.appending(self.components)
+        }
+        else
+        {
+            fatalError("Couldn’t determine the current working directory!")
+        }
+    }
+}

--- a/Sources/SymbolGraphBuilder/FilePath.Directory (ext).swift
+++ b/Sources/SymbolGraphBuilder/FilePath.Directory (ext).swift
@@ -1,0 +1,7 @@
+import System
+
+extension FilePath.Directory
+{
+    func absolute() -> Self { .init(path: self.path.absolute()) }
+}
+

--- a/Sources/SymbolGraphBuilder/SSGC.Compile.swift
+++ b/Sources/SymbolGraphBuilder/SSGC.Compile.swift
@@ -239,13 +239,14 @@ extension SSGC.Compile
         {
             let build:SSGC.PackageBuild = .local(project: self.name,
                 among: search,
+                using: ".build.ssgc",
                 as: self.type)
 
             defer
             {
                 if  self.removeBuild
                 {
-                    try? (build.root / toolchain.scratch).remove()
+                    try? build.scratch.location.remove()
                 }
             }
 
@@ -267,11 +268,6 @@ extension SSGC.Compile
                 {
                     try? repoClone.remove()
                 }
-                else if
-                    self.removeBuild
-                {
-                    try? (repoClone / toolchain.scratch).remove()
-                }
             }
 
             let build:SSGC.PackageBuild = try .remote(project: self.name,
@@ -279,6 +275,14 @@ extension SSGC.Compile
                 at: ref,
                 as: self.type,
                 in: workspace)
+
+            defer
+            {
+                if  self.removeBuild
+                {
+                    try? build.scratch.location.remove()
+                }
+            }
 
             try status?.send(.didCloneRepository)
 

--- a/Sources/SymbolGraphBuilder/SSGC.PackageGraph.swift
+++ b/Sources/SymbolGraphBuilder/SSGC.PackageGraph.swift
@@ -132,10 +132,13 @@ extension SSGC.PackageGraph
 
         self.createEdges(from: sinkManifest, as: id)
 
-        print("""
-            Note: the following packages were never used in any documentation-bearing product:
-            """)
-
+        if !self.packagesUnused.isEmpty
+        {
+            print("""
+                Note: \
+                the following packages were never used in any documentation-bearing product:
+                """)
+        }
         for (i, package):(Int, Symbol.Package) in self.packagesUnused.sorted().enumerated()
         {
             print("\(i + 1). \(package)")

--- a/Sources/SymbolGraphBuilder/Sources/SSGC.BookSources.swift
+++ b/Sources/SymbolGraphBuilder/Sources/SSGC.BookSources.swift
@@ -56,6 +56,9 @@ extension SSGC.BookSources:SSGC.DocumentationSources
     var snippets:[SSGC.LazyFile] { [] }
 
     @_spi(testable) public
+    var symbols:[FilePath.Directory] { [] }
+
+    @_spi(testable) public
     var prefix:Symbol.FileBase? { .init(self.root.location.path.string) }
 
 

--- a/Sources/SymbolGraphBuilder/Sources/SSGC.DocumentationSources.swift
+++ b/Sources/SymbolGraphBuilder/Sources/SSGC.DocumentationSources.swift
@@ -14,6 +14,8 @@ extension SSGC
 {
     protocol DocumentationSources
     {
+        var symbols:[FilePath.Directory] { get }
+
         var cultures:[ModuleLayout] { get }
         var snippets:[LazyFile] { get }
 
@@ -29,20 +31,18 @@ extension SSGC
 }
 extension SSGC.DocumentationSources
 {
-    func link(symbols:SSGC.SymbolDumps,
-        logger:SSGC.Logger,
-        with swift:SSGC.Toolchain) throws -> SymbolGraph
+    func link(logger:SSGC.Logger, with swift:SSGC.Toolchain) throws -> SymbolGraph
     {
         let moduleLayouts:[SSGC.ModuleLayout] = self.cultures
         let snippets:[SSGC.LazyFile] = self.snippets
         let prefix:Symbol.FileBase? = self.prefix
 
-        let moduleIndexes:[SSGC.ModuleIndex] 
+        let moduleIndexes:[SSGC.ModuleIndex]
 
         var profiler:SSGC.DocumentationBuildProfiler = .init()
         do
         {
-            var symbolCache:SSGC.SymbolCache = .init(symbols: symbols)
+            var symbolCache:SSGC.SymbolCache = .init(symbols: try .collect(from: self.symbols))
 
             moduleIndexes = try moduleLayouts.map
             {
@@ -146,8 +146,8 @@ extension SSGC.DocumentationSources
                     indexes: moduleIndexes,
                     snippets: snippets,
                     logger: logger)
-            } 
-            
+            }
+
             for resource:SSGC.LazyFile in moduleLayouts.lazy.map(\.resources).joined()
             {
                 profiler.loadingSources += resource.loadingTime

--- a/Sources/SymbolGraphBuilder/Sources/SSGC.PackageSources.swift
+++ b/Sources/SymbolGraphBuilder/Sources/SSGC.PackageSources.swift
@@ -24,6 +24,7 @@ extension SSGC
         var snippets:[LazyFile]
 
         let scratch:PackageBuildDirectory
+        let symbols:[FilePath.Directory]
 
         private
         let modules:ModuleGraph
@@ -31,10 +32,12 @@ extension SSGC
         init(
             snippets:[LazyFile] = [],
             scratch:PackageBuildDirectory,
+            symbols:[FilePath.Directory],
             modules:ModuleGraph)
         {
             self.snippets = snippets
             self.scratch = scratch
+            self.symbols = symbols
             self.modules = modules
         }
     }

--- a/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibrary.swift
+++ b/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibrary.swift
@@ -131,4 +131,3 @@ extension SSGC.StandardLibrary
             ])
     }
 }
-

--- a/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibraryBuild.swift
+++ b/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibraryBuild.swift
@@ -20,23 +20,23 @@ extension SSGC.StandardLibraryBuild
 extension SSGC.StandardLibraryBuild:SSGC.DocumentationBuild
 {
     func compile(updating _:SSGC.StatusStream?,
-        into artifacts:FilePath.Directory,
+        cache:FilePath.Directory,
         with swift:SSGC.Toolchain,
         clean _:Bool) throws -> (SymbolGraphMetadata, any SSGC.DocumentationSources)
     {
         let standardLibrary:SSGC.StandardLibrary = .init(platform: try swift.platform())
 
-        let metadata:SymbolGraphMetadata = .swift(swift.version,
+        let artifacts:FilePath.Directory = try swift.dump(standardLibrary: standardLibrary,
+            options: .default,
+            cache: cache)
+
+        let metadata:SymbolGraphMetadata = .swift(swift.id,
             commit: swift.commit,
             triple: swift.triple,
             products: standardLibrary.products)
 
-        for module:SymbolGraph.Module in standardLibrary.modules
-        {
-            try swift.dump(module: module.id, to: artifacts)
-        }
-
-        let sources:SSGC.StandardLibrarySources = .init(modules: standardLibrary.modules)
+        let sources:SSGC.StandardLibrarySources = .init(modules: standardLibrary.modules,
+            symbols: [artifacts])
         return (metadata, sources)
     }
 }

--- a/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibrarySources.swift
+++ b/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibrarySources.swift
@@ -1,6 +1,7 @@
 import MarkdownABI
 import SymbolGraphs
 import Symbols
+import System
 
 extension SSGC
 {
@@ -8,19 +9,21 @@ extension SSGC
     struct StandardLibrarySources
     {
         let cultures:[ModuleLayout]
+        let symbols:[FilePath.Directory]
 
         private
-        init(cultures:[ModuleLayout])
+        init(cultures:[ModuleLayout], symbols:[FilePath.Directory])
         {
             self.cultures = cultures
+            self.symbols = symbols
         }
     }
 }
 extension SSGC.StandardLibrarySources
 {
-    init(modules:[SymbolGraph.Module])
+    init(modules:[SymbolGraph.Module], symbols:[FilePath.Directory])
     {
-        self.init(cultures: modules.map(SSGC.ModuleLayout.init(toolchain:)))
+        self.init(cultures: modules.map(SSGC.ModuleLayout.init(toolchain:)), symbols: symbols)
     }
 }
 extension SSGC.StandardLibrarySources:SSGC.DocumentationSources

--- a/Sources/SymbolGraphBuilderTests/Main.swift
+++ b/Sources/SymbolGraphBuilderTests/Main.swift
@@ -80,6 +80,8 @@ enum Main:TestMain, TestBattery
                     project: "swift-snippets",
                     among: "TestPackages")
 
+                try workspace.cache.create()
+
                 let (_, sources):(_, SSGC.PackageSources) = try package.compileSwiftPM(
                     cache: workspace.cache,
                     with: toolchain)

--- a/Sources/SymbolGraphBuilderTests/Main.swift
+++ b/Sources/SymbolGraphBuilderTests/Main.swift
@@ -24,7 +24,7 @@ enum Main:TestMain, TestBattery
 
                     """))
             {
-                tests.expect(swift.version ==? .init(version: .v(5, 8, 0),
+                tests.expect(swift.id ==? .init(version: .v(5, 8, 0),
                     nightly: .DEVELOPMENT_SNAPSHOT))
                 tests.expect(swift.triple ==? .init("x86_64", "unknown", "linux", "gnu"))
             }
@@ -35,7 +35,7 @@ enum Main:TestMain, TestBattery
 
                     """))
             {
-                tests.expect(swift.version ==? .init(version: .v(5, 10, 0), nightly: nil))
+                tests.expect(swift.id ==? .init(version: .v(5, 10, 0), nightly: nil))
                 tests.expect(swift.triple ==? .init("x86_64", "unknown", "linux", "gnu"))
             }
             if  let tests:TestGroup = tests / "Xcode",
@@ -46,7 +46,7 @@ enum Main:TestMain, TestBattery
 
                     """))
             {
-                tests.expect(swift.version ==? .init(version: .v(5, 10, 0), nightly: nil))
+                tests.expect(swift.id ==? .init(version: .v(5, 10, 0), nightly: nil))
                 tests.expect(swift.triple ==? .init("arm64", "apple", "macosx14.0", nil))
             }
         }
@@ -67,7 +67,7 @@ enum Main:TestMain, TestBattery
                 try workspace.build(special: .swift, with: toolchain)
             })
         {
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
 
         #if canImport(IndexStoreDB)
@@ -80,10 +80,8 @@ enum Main:TestMain, TestBattery
                     project: "swift-snippets",
                     among: "TestPackages")
 
-                try workspace.artifacts.create()
-
                 let (_, sources):(_, SSGC.PackageSources) = try package.compileSwiftPM(
-                    into: workspace.artifacts,
+                    cache: workspace.cache,
                     with: toolchain)
 
                 let parser:Markdown.SwiftLanguage = .swift(
@@ -148,7 +146,7 @@ enum Main:TestMain, TestBattery
                 tests.expect(docs.graph.cultures.count >? 0)
                 tests.expect(docs.graph.decls.nodes.count >? 0)
 
-                docs.roundtrip(for: tests, in: workspace.artifacts)
+                docs.roundtrip(for: tests, in: workspace.location)
             }
         }
 
@@ -231,7 +229,7 @@ enum Main:TestMain, TestBattery
             tests.expect(docs.graph.cultures.count >? 0)
             tests.expect(docs.graph.decls.nodes.count >? 0)
 
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
 
         //  https://github.com/tayloraswift/swift-unidoc/issues/211
@@ -258,7 +256,7 @@ enum Main:TestMain, TestBattery
             tests.expect(docs.graph.cultures.count >? 0)
             tests.expect(docs.graph.decls.nodes.count >? 0)
 
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
         #endif
 
@@ -284,7 +282,7 @@ enum Main:TestMain, TestBattery
             tests.expect(docs.graph.cultures.count >? 0)
             tests.expect(docs.graph.decls.nodes.count >? 0)
 
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
 
         //  The swift-async-dns-resolver repo includes a git submodule, so we should be able
@@ -309,7 +307,7 @@ enum Main:TestMain, TestBattery
             tests.expect(docs.graph.cultures.count >? 0)
             tests.expect(docs.graph.decls.nodes.count >? 0)
 
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
 
         //  SwiftSyntax is a morbidly obese package. If we can handle SwiftSyntax,
@@ -331,7 +329,7 @@ enum Main:TestMain, TestBattery
             tests.expect(docs.graph.cultures.count >? 0)
             tests.expect(docs.graph.decls.nodes.count >? 0)
 
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
 
         //  The swift-snapshot-testing package at 1.17.0 has a dependency on SwiftSyntax with
@@ -357,7 +355,7 @@ enum Main:TestMain, TestBattery
             tests.expect(docs.graph.cultures.count >? 0)
             tests.expect(docs.graph.decls.nodes.count >? 0)
 
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
         #endif
 
@@ -399,7 +397,7 @@ enum Main:TestMain, TestBattery
             tests.expect(docs.graph.articles.nodes.count >? 0)
             tests.expect(docs.graph.decls.nodes.count ==? 0)
 
-            docs.roundtrip(for: tests, in: workspace.artifacts)
+            docs.roundtrip(for: tests, in: workspace.location)
         }
     }
 }

--- a/Sources/SymbolGraphLinker/Resolution/SSGC.OutlineDiagnostic.swift
+++ b/Sources/SymbolGraphLinker/Resolution/SSGC.OutlineDiagnostic.swift
@@ -1,3 +1,4 @@
+import FNV1
 import SourceDiagnostics
 import UCF
 
@@ -5,6 +6,7 @@ extension SSGC
 {
     enum OutlineDiagnostic:Equatable, Error
     {
+        case annealedIncorrectHash(in:UCF.Selector, to:FNV24)
         case unresolvedAbsolute(Doclink)
         case suggestReformat(Doclink, to:UCF.Selector)
     }
@@ -17,8 +19,14 @@ extension SSGC.OutlineDiagnostic:Diagnostic
     {
         switch self
         {
+        case .annealedIncorrectHash(in: let selector, to: _):
+            output[.warning] = """
+            codelink '\(selector)' is unambiguous, but the hash does not match the resolved \
+            declaration
+            """
+
         case .unresolvedAbsolute(let doclink):
-            output[.note] = """
+            output[.warning] = """
             doclink '\(doclink)' does not resolve to any article (or tutorial) in this package
             """
 
@@ -33,6 +41,11 @@ extension SSGC.OutlineDiagnostic:Diagnostic
     {
         switch self
         {
+        case .annealedIncorrectHash(in: _, to: let hash):
+            output[.note] = """
+            replace the hash with [\(hash)] to suppress this warning
+            """
+
         case .unresolvedAbsolute:
             output[.note] = """
             absolute doclinks may only refer to articles (or tutorials), not to symbol \

--- a/Sources/SymbolGraphs/SymbolGraphABI.swift
+++ b/Sources/SymbolGraphs/SymbolGraphABI.swift
@@ -3,5 +3,5 @@ import SemanticVersions
 @frozen public
 enum SymbolGraphABI
 {
-    @inlinable public static var version:PatchVersion { .v(0, 10, 0) }
+    @inlinable public static var version:PatchVersion { .v(0, 10, 1) }
 }

--- a/Sources/System/FilePath.Directory.swift
+++ b/Sources/System/FilePath.Directory.swift
@@ -77,6 +77,17 @@ extension FilePath.Directory
         try SystemProcess.init(command: "rm", "-rf", "\(self.path)")()
     }
 
+    public
+    func move(into location:FilePath.Directory) throws
+    {
+        try SystemProcess.init(command: "mv", "\(self.path)", "\(location.path)/.")()
+    }
+    public
+    func move(replacing destination:FilePath.Directory) throws
+    {
+        try SystemProcess.init(command: "mv", "-f", "\(self.path)", "\(destination.path)")()
+    }
+
     /// Returns true if a directory exists at ``path``, returns false if
     /// the file does not exist or is not a directory. This method follows symlinks.
     public

--- a/Sources/UnidocQueryTests/Tests/LinkResolution.swift
+++ b/Sources/UnidocQueryTests/Tests/LinkResolution.swift
@@ -28,7 +28,7 @@ struct LinkResolution:UnidocDatabaseTestBattery
         do
         {
             //  Use the cached binary if available.
-            swift = try .load(swift: toolchain.version, in: workspace.location)
+            swift = try .load(swift: toolchain.id, in: workspace.location)
         }
         catch
         {

--- a/Sources/UnidocQueryTests/Tests/SymbolQueries.swift
+++ b/Sources/UnidocQueryTests/Tests/SymbolQueries.swift
@@ -33,7 +33,7 @@ struct SymbolQueries:UnidocDatabaseTestBattery
         do
         {
             //  Use the cached binary if available.
-            swift = try .load(swift: toolchain.version, in: workspace.location)
+            swift = try .load(swift: toolchain.id, in: workspace.location)
         }
         catch
         {

--- a/Sources/UnidocQueryTests/Tests/VolumeQueries.swift
+++ b/Sources/UnidocQueryTests/Tests/VolumeQueries.swift
@@ -31,7 +31,7 @@ struct VolumeQueries:UnidocDatabaseTestBattery
                     package: .init(name: package),
                     commit: .init(name: tag),
                     triple: swift.triple,
-                    swift: swift.version),
+                    swift: swift.id),
                 graph: .init(modules: []))
 
             empty.roundtrip(for: tests, in: workspace.location)


### PR DESCRIPTION
this makes SSGC slightly faster in development workflows, as it will not need to regenerate the standard library symbols JSON on every run.

it also moves package-specific artifacts to the package’s build directory, to reduce the chance of conflicts