### PR TITLE
Turn off extension block symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
         branches: [ master ]
 
 jobs:
-    linux:
-        runs-on: ubuntu-22.04
+    server:
+        runs-on: ubuntu-24.04
         name: Amazon Linux 2023
 
         strategy:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,36 +43,12 @@ jobs:
     linux:
         runs-on: ubuntu-24.04
         name: Ubuntu 24.04
-
-        env:
-            SWIFT_PREFIX: "swift-5.10.1-release/ubuntu2404/swift-5.10.1-RELEASE"
-            SWIFT_ID: "swift-5.10.1-RELEASE-ubuntu24.04"
-
         steps:
-            -   name: Cache Swift toolchain
-                uses: actions/cache@v2
+            -   name: Install Swift
+                uses: tayloraswift/swift-install-action@master
                 with:
-                    path: ${{ env.SWIFT_ID }}.tar.gz
-                    key: ${{ env.SWIFT_ID }}
-
-            -   name: Cache status
-                id:   cache_status
-                uses: andstor/file-existence-action@v1
-                with:
-                    files: ${{ env.SWIFT_ID }}.tar.gz
-
-            -   name: Download Swift
-                if: steps.cache_status.outputs.files_exists == 'false'
-                run: |
-                    curl https://download.swift.org/$SWIFT_PREFIX/$SWIFT_ID.tar.gz \
-                        --output $SWIFT_ID.tar.gz
-
-            -   name: Set up Swift
-                run: |
-                    mkdir -p $HOME/$SWIFT_ID
-                    tar -xzf $SWIFT_ID.tar.gz -C $HOME/$SWIFT_ID --strip 1
-                    echo "$HOME/$SWIFT_ID/usr/bin" >> $GITHUB_PATH
-                    cat $GITHUB_PATH
+                    swift-prefix: "swift-5.10.1-release/ubuntu2404/swift-5.10.1-RELEASE"
+                    swift-id: "swift-5.10.1-RELEASE-ubuntu24.04"
 
             #   This clobbers everything in the current directory, which is why we installed
             #   the Swift toolchain in the home directory.
@@ -89,13 +65,13 @@ jobs:
                     swift build -c release \
                         --static-swift-stdlib \
                         --product unidoc-publish \
-                        -Xcxx -I$HOME/$SWIFT_ID/usr/lib/swift \
-                        -Xcxx -I$HOME/$SWIFT_ID/usr/lib/swift/Block
+                        -Xcxx -I$SWIFT_INSTALLATION/lib/swift \
+                        -Xcxx -I$SWIFT_INSTALLATION/lib/swift/Block
                     swift build -c release \
                         --static-swift-stdlib \
                         --product unidoc-tools \
-                        -Xcxx -I$HOME/$SWIFT_ID/usr/lib/swift \
-                        -Xcxx -I$HOME/$SWIFT_ID/usr/lib/swift/Block
+                        -Xcxx -I$SWIFT_INSTALLATION/lib/swift \
+                        -Xcxx -I$SWIFT_INSTALLATION/lib/swift/Block
 
             -   name: Upload products
                 env:

--- a/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.PackageBuild.swift
@@ -302,7 +302,7 @@ extension SSGC.PackageBuild
         {
             try toolchain.build(package: self.root,
                 using: self.scratch,
-                flags: self.flags.dumping(symbols: .default, to: artifacts))
+                flags: self.flags.dumping(symbols: .init(), to: artifacts))
         }
         catch SystemProcessError.exit(let code, let invocation)
         {
@@ -331,14 +331,13 @@ extension SSGC.PackageBuild
         //  Dump the standard library’s symbols, unless they’re already cached.
         let artifactsCached:FilePath.Directory = try toolchain.dump(
             standardLibrary: .init(platform: platform),
-            options: .default,
             cache: cache)
         for (module, include):(Symbol.Module, [FilePath.Directory]) in try self.modulesToDump(
             among: modules)
         {
             try toolchain.dump(module: module,
                 to: artifacts,
-                options: .default,
+                options: .init(),
                 include: include)
         }
 

--- a/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibraryBuild.swift
+++ b/Sources/SymbolGraphBuilder/Standard library/SSGC.StandardLibraryBuild.swift
@@ -27,7 +27,6 @@ extension SSGC.StandardLibraryBuild:SSGC.DocumentationBuild
         let standardLibrary:SSGC.StandardLibrary = .init(platform: try toolchain.platform())
 
         let artifacts:FilePath.Directory = try toolchain.dump(standardLibrary: standardLibrary,
-            options: .default,
             cache: cache)
 
         let metadata:SymbolGraphMetadata = .swift(toolchain.splash.swift,

--- a/Sources/SymbolGraphBuilder/Toolchains/SSGC.Toolchain.SymbolDumpOptions.swift
+++ b/Sources/SymbolGraphBuilder/Toolchains/SSGC.Toolchain.SymbolDumpOptions.swift
@@ -9,26 +9,15 @@ extension SSGC.Toolchain
         var includeInterfaceSymbols:Bool
         var skipInheritedDocs:Bool
 
-        init(minimumACL:Symbol.ACL,
-            emitExtensionBlockSymbols:Bool,
-            includeInterfaceSymbols:Bool,
-            skipInheritedDocs:Bool)
+        init(minimumACL:Symbol.ACL = .internal,
+            emitExtensionBlockSymbols:Bool = true,
+            includeInterfaceSymbols:Bool = true,
+            skipInheritedDocs:Bool = true)
         {
             self.minimumACL = minimumACL
             self.emitExtensionBlockSymbols = emitExtensionBlockSymbols
             self.includeInterfaceSymbols = includeInterfaceSymbols
             self.skipInheritedDocs = skipInheritedDocs
         }
-    }
-}
-extension SSGC.Toolchain.SymbolDumpOptions
-{
-    static
-    var `default`:Self
-    {
-        .init(minimumACL: .internal,
-            emitExtensionBlockSymbols: true,
-            includeInterfaceSymbols: true,
-            skipInheritedDocs: true)
     }
 }

--- a/Sources/SymbolGraphBuilder/Toolchains/SSGC.Toolchain.swift
+++ b/Sources/SymbolGraphBuilder/Toolchains/SSGC.Toolchain.swift
@@ -208,8 +208,10 @@ extension SSGC.Toolchain
 }
 extension SSGC.Toolchain
 {
+    /// Dumps the symbols for the standard library. Due to upstream bugs in the Swift compiler,
+    /// this methods disables extension block symbols by default.
     func dump(standardLibrary:SSGC.StandardLibrary,
-        options:SymbolDumpOptions = .default,
+        options:SymbolDumpOptions = .init(emitExtensionBlockSymbols: false),
         cache:FilePath.Directory) throws -> FilePath.Directory
     {
         let cached:FilePath.Directory = cache / "swift@\(self.splash.swift.version)"
@@ -234,7 +236,7 @@ extension SSGC.Toolchain
     /// output directory.
     func dump(module id:Symbol.Module,
         to output:FilePath.Directory,
-        options:SymbolDumpOptions = .default,
+        options:SymbolDumpOptions,
         include:[FilePath.Directory] = []) throws
     {
         print("Dumping symbols for module '\(id)'")

--- a/Sources/SymbolGraphCompiler/Extensions/SSGC.Extensions.swift
+++ b/Sources/SymbolGraphCompiler/Extensions/SSGC.Extensions.swift
@@ -25,6 +25,13 @@ extension SSGC
 }
 extension SSGC.Extensions
 {
+    var all:Dictionary<SSGC.ExtensionSignature, SSGC.ExtensionObject>.Values
+    {
+        self.groups.values
+    }
+}
+extension SSGC.Extensions
+{
     mutating
     func include(_ vertex:SymbolGraphPart.Vertex,
         extending type:__owned Symbol.Decl,
@@ -114,7 +121,7 @@ extension SSGC.Extensions
         /// Gather extension members attributable to the specified culture, simplifying the
         /// extension signatures by inspecting the extended declaration. This may coalesce
         /// multiple extension objects into a single extension layer.
-        let coalesced:[SSGC.Extension.ID: SSGC.ExtensionLayer] = try self.groups.values.reduce(
+        let coalesced:[SSGC.Extension.ID: SSGC.ExtensionLayer] = try self.all.reduce(
             into: [:])
         {
             let blocks:[(id:Symbol.Block, block:SSGC.Extension.Block)] = $1.blocks.reduce(

--- a/Sources/SymbolGraphCompiler/SSGC.TypeChecker.swift
+++ b/Sources/SymbolGraphCompiler/SSGC.TypeChecker.swift
@@ -11,8 +11,6 @@ extension SSGC
     struct TypeChecker
     {
         private
-        let ignoreExportedInterfaces:Bool
-        private
         var declarations:Declarations
         private
         var extensions:Extensions
@@ -23,9 +21,8 @@ extension SSGC
         var resolvableModules:[Symbol.Module]
 
         public
-        init(ignoreExportedInterfaces:Bool = true, threshold:Symbol.ACL = .public)
+        init(threshold:Symbol.ACL = .public)
         {
-            self.ignoreExportedInterfaces = ignoreExportedInterfaces
             self.declarations = .init(threshold: threshold)
             self.extensions = .init()
 

--- a/Sources/SymbolGraphCompiler/SSGC.TypeChecker.swift
+++ b/Sources/SymbolGraphCompiler/SSGC.TypeChecker.swift
@@ -258,16 +258,6 @@ extension SSGC.TypeChecker
             return
         }
 
-        guard self.ignoreExportedInterfaces || member.culture == culture
-        else
-        {
-            throw AssertionError.init(message: """
-                Found cross-module member relationship \
-                (from \(member.culture) in \(culture)), which should not be possible in \
-                symbol dumps generated with '-emit-extension-symbols'
-                """)
-        }
-
         switch relationship.target
         {
         case .vector(let symbol):
@@ -275,22 +265,11 @@ extension SSGC.TypeChecker
             throw SSGC.UnexpectedSymbolError.vector(symbol)
 
         case .scalar(let scope):
-            //  We should never see an external type reference here either.
             guard
             let scope:SSGC.DeclObject = self.declarations[visible: scope]
             else
             {
                 return
-            }
-
-            guard self.ignoreExportedInterfaces || scope.culture == culture
-            else
-            {
-                throw AssertionError.init(message: """
-                    Found cross-module member relationship \
-                    (to \(scope.culture) in \(culture)), which should not be possible in \
-                    symbol dumps generated with '-emit-extension-symbols'
-                    """)
             }
 
             //  Enum cases are considered intrinsic members of their parent enum.
@@ -358,16 +337,6 @@ extension SSGC.TypeChecker
                 return
             }
 
-            guard self.ignoreExportedInterfaces || type.culture == culture
-            else
-            {
-                throw AssertionError.init(message: """
-                    Found cross-module conformance relationship \
-                    (from \(type.culture) in \(culture)), which should not be possible in \
-                    symbol dumps generated with '-emit-extension-symbols'
-                    """)
-            }
-
             if  let origin:Symbol.Decl = conformance.origin
             {
                 type.assign(origin: origin)
@@ -422,14 +391,6 @@ extension SSGC.TypeChecker
             return
         }
 
-        guard self.ignoreExportedInterfaces || subform.culture == culture
-        else
-        {
-            throw AssertionError.init(message: """
-                Found retroactive superform relationship (from \(subform.culture) in \(culture))
-                """)
-        }
-
         try subform.add(superform: relationship)
 
         /// Having a universal witness is not intrinsic, but it is useful to know
@@ -459,8 +420,6 @@ extension SSGC.TypeChecker
             throw SSGC.UnexpectedSymbolError.vector(symbol)
 
         case .scalar(let symbol):
-            //  If the colonial graph was generated with '-emit-extension-symbols',
-            //  we should never see an external type reference here.
             if  let decl:SSGC.DeclObject = self.declarations[visible: symbol]
             {
                 heir = decl
@@ -470,16 +429,6 @@ extension SSGC.TypeChecker
                 return
             }
 
-            guard self.ignoreExportedInterfaces || heir.culture == culture
-            else
-            {
-                throw AssertionError.init(message: """
-                    Found direct cross-module feature inheritance relationship in culture \
-                    '\(culture)' adding feature '\(feature.value.path)' to type \
-                    '\(heir.value.path)' from '\(heir.culture)', which should not be \
-                    possible in symbol dumps generated with '-emit-extension-symbols'
-                    """)
-            }
             guard heir.id == relationship.source.heir
             else
             {

--- a/Sources/SymbolGraphCompiler/SSGC.TypeChecker.swift
+++ b/Sources/SymbolGraphCompiler/SSGC.TypeChecker.swift
@@ -525,16 +525,29 @@ extension SSGC.TypeChecker
                     """)
             }
         }
-
-        self.resolvableLinks[heir.namespace, heir.value.path, feature.value.path.last].append(
-            .feature(feature.value, self: heir.id))
     }
 }
 extension SSGC.TypeChecker
 {
-    public __consuming
+    public consuming
     func load(in culture:Symbol.Module) throws -> SSGC.ModuleIndex
     {
+        for `extension`:SSGC.ExtensionObject in self.extensions.all
+        {
+            //  We add the feature paths here and not in `insert(_:by:)` because those
+            //  edges are frequently duplicated, and it is hard to remove duplicate paths
+            //  after they have been added.
+            let extendee:SSGC.DeclObject = try self.declarations[`extension`.extendee]
+            for feature:Symbol.Decl in `extension`.features.keys
+            {
+                let feature:SSGC.Decl = try self.declarations[feature].value
+                let last:String = feature.path.last
+
+                self.resolvableLinks[extendee.namespace, extendee.value.path, last].append(
+                    .feature(feature, self: extendee.id))
+            }
+        }
+
         let extensions:[SSGC.Extension] = try self.extensions.load(culture: culture,
             with: self.declarations)
 

--- a/Sources/SymbolGraphs/SymbolGraphABI.swift
+++ b/Sources/SymbolGraphs/SymbolGraphABI.swift
@@ -3,5 +3,5 @@ import SemanticVersions
 @frozen public
 enum SymbolGraphABI
 {
-    @inlinable public static var version:PatchVersion { .v(0, 10, 2) }
+    @inlinable public static var version:PatchVersion { .v(0, 10, 3) }
 }


### PR DESCRIPTION
Unidoc is effectively unusable on many platforms as it currently requires a `noassert` Swift toolchain, due to:

- https://github.com/swiftlang/swift/issues/68767
- https://github.com/swiftlang/swift/issues/71635

the immediate trigger on our end is using `-emit-extension-block-symbols`, so this PR disables that when dumping the standard library, and updates the documentation compiler to not assume this flag was enabled when parsing raw symbol graphs.