### PR TITLE
lightweight dynamic linker optimized for SGABI ≥ 0.10

### DIFF
--- a/Sources/SymbolGraphCompiler/Declarations/SSGC.DeclObject.swift
+++ b/Sources/SymbolGraphCompiler/Declarations/SSGC.DeclObject.swift
@@ -27,7 +27,8 @@ extension SSGC
         ///
         /// In the example above, the second conformance likely originated from a
         /// `Foo<T>:Hashable where T:Hashable` conformance.
-        var conformances:[Symbol.Decl: Set<Set<GenericConstraint<Symbol.Decl>>>]
+        var conformanceStatements:[Symbol.Decl: Set<Set<GenericConstraint<Symbol.Decl>>>]
+        var conformances:[Symbol.Decl: Set<GenericConstraint<Symbol.Decl>>]
 
         /// The type of the superforms tracked by ``\.value.superforms``.
         var superforms:(any SuperformRelationship.Type)?
@@ -54,6 +55,7 @@ extension SSGC
             self.culture = culture
             self.access = access
 
+            self.conformanceStatements = [:]
             self.conformances = [:]
             self.superforms = nil
             self.scopes = []
@@ -61,6 +63,14 @@ extension SSGC
             self.value = value
         }
     }
+}
+extension SSGC.DeclObject:Equatable
+{
+    static func == (a:SSGC.DeclObject, b:SSGC.DeclObject) -> Bool { a === b }
+}
+extension SSGC.DeclObject:Hashable
+{
+    func hash(into hasher:inout Hasher) { hasher.combine(ObjectIdentifier.init(self)) }
 }
 extension SSGC.DeclObject
 {

--- a/Sources/SymbolGraphCompiler/Set (ext).swift
+++ b/Sources/SymbolGraphCompiler/Set (ext).swift
@@ -3,32 +3,6 @@ import Symbols
 
 extension Set<Set<GenericConstraint<Symbol.Decl>>>
 {
-    mutating
-    func simplify(
-        with declarations:SSGC.Declarations) throws -> Set<GenericConstraint<Symbol.Decl>>
-    {
-        guard
-        var first:Set<GenericConstraint<Symbol.Decl>> = self.first
-        else
-        {
-            return []
-        }
-
-        if  self.count == 1
-        {
-            return first
-        }
-        else
-        {
-            first = try self.simplified(with: declarations)
-        }
-
-        //  Cache the simplified constraints so that the next query is faster.
-        self = [first]
-        return first
-    }
-
-    private
     func simplified(
         with declarations:SSGC.Declarations) throws -> Set<GenericConstraint<Symbol.Decl>>
     {

--- a/Sources/SymbolGraphCompiler/SymbolRelationship (ext).swift
+++ b/Sources/SymbolGraphCompiler/SymbolRelationship (ext).swift
@@ -2,11 +2,11 @@ import SymbolGraphParts
 
 extension SymbolRelationship
 {
-    func `do`(_ body:(Self) throws -> Void) rethrows
+    func `do`<T>(_ body:(Self) throws -> T) rethrows -> T
     {
         do
         {
-            try body(self)
+            return try body(self)
         }
         catch let error
         {

--- a/Sources/SymbolGraphs/SymbolGraphABI.swift
+++ b/Sources/SymbolGraphs/SymbolGraphABI.swift
@@ -3,5 +3,5 @@ import SemanticVersions
 @frozen public
 enum SymbolGraphABI
 {
-    @inlinable public static var version:PatchVersion { .v(0, 10, 3) }
+    @inlinable public static var version:PatchVersion { .v(0, 11, 0) }
 }

--- a/Sources/UnidocLinker/Sema/Unidoc.Linker.Tables.swift
+++ b/Sources/UnidocLinker/Sema/Unidoc.Linker.Tables.swift
@@ -32,7 +32,7 @@ extension Unidoc.Linker
         var peers:[Int32: Unidoc.Group]
 
         private
-        var next:Next
+        var next:Unidoc.LinkerTables.Next
 
         private(set)
         var extensions:Unidoc.Linker.Table<Unidoc.Extension>

--- a/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.Counter.swift
+++ b/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.Counter.swift
@@ -1,4 +1,4 @@
-extension Unidoc.Linker.Tables
+extension Unidoc.LinkerTables
 {
     struct Counter
     {
@@ -11,7 +11,7 @@ extension Unidoc.Linker.Tables
         }
     }
 }
-extension Unidoc.Linker.Tables.Counter
+extension Unidoc.LinkerTables.Counter
 {
     mutating
     func callAsFunction() -> Int

--- a/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.ModuleContext.swift
+++ b/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.ModuleContext.swift
@@ -1,0 +1,13 @@
+import SymbolGraphs
+import Symbols
+import Unidoc
+
+extension Unidoc.LinkerTables
+{
+    struct ModuleContext
+    {
+        let culture:SymbolGraph.Culture
+        let symbol:Symbol.Module
+        let id:Unidoc.Scalar
+    }
+}

--- a/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.ModuleNamespace.swift
+++ b/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.ModuleNamespace.swift
@@ -1,0 +1,16 @@
+import Symbols
+import Unidoc
+
+extension Unidoc.LinkerTables
+{
+    struct ModuleNamespace
+    {
+        let culture:Unidoc.Scalar
+        let colony:Unidoc.Scalar
+        let symbol:Symbol.Module
+    }
+}
+extension Unidoc.LinkerTables.ModuleNamespace
+{
+    var cultureOffset:Int { .init(self.culture.citizen) }
+}

--- a/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.ModuleView.swift
+++ b/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.ModuleView.swift
@@ -1,0 +1,35 @@
+import SymbolGraphs
+import Symbols
+import Unidoc
+import UnidocRecords
+
+extension Unidoc.LinkerTables
+{
+    struct ModuleView
+    {
+        let namespaces:[Symbol.Module]
+        let cultures:[SymbolGraph.Culture]
+        let edition:Unidoc.Edition
+
+        init(namespaces:[Symbol.Module],
+            cultures:[SymbolGraph.Culture],
+            edition:Unidoc.Edition)
+        {
+            self.namespaces = namespaces
+            self.cultures = cultures
+            self.edition = edition
+        }
+    }
+}
+extension Unidoc.LinkerTables.ModuleView:RandomAccessCollection
+{
+    var startIndex:Int { self.cultures.startIndex }
+    var endIndex:Int { self.cultures.endIndex }
+
+    subscript(culture:Int) -> Unidoc.LinkerTables.ModuleContext
+    {
+        .init(culture: self.cultures[culture],
+            symbol: self.namespaces[culture],
+            id: self.edition + culture)
+    }
+}

--- a/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.Next.swift
+++ b/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.Next.swift
@@ -1,6 +1,6 @@
 import UnidocRecords
 
-extension Unidoc.Linker.Tables
+extension Unidoc.LinkerTables
 {
     /// A type that can generate ``Unidoc.Group`` identifiers.
     struct Next
@@ -17,7 +17,7 @@ extension Unidoc.Linker.Tables
         }
     }
 }
-extension Unidoc.Linker.Tables.Next
+extension Unidoc.LinkerTables.Next
 {
     mutating
     func callAsFunction(_ type:Unidoc.GroupType) -> Unidoc.Group

--- a/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.swift
+++ b/Sources/UnidocLinker/Sema/Unidoc.LinkerTables.swift
@@ -1,0 +1,474 @@
+import JSON
+import LinkResolution
+import SourceDiagnostics
+import SymbolGraphs
+import Symbols
+import Unidoc
+import UnidocRecords
+
+extension Unidoc
+{
+    struct LinkerTables
+    {
+        private(set)
+        var linker:Linker
+
+        /// A table mapping vertices to topics or autogroups.
+        private
+        var group:[Int32: Group]
+        private
+        var peers:[Int32: Group]
+
+        private
+        var next:Next
+
+        private(set)
+        var extensions:Linker.Table<Extension>
+        private(set)
+        var groups:Mesh.Groups
+
+        private
+        init(linker:consuming Linker, next:Next)
+        {
+            self.linker = linker
+
+            self.group = [:]
+            self.peers = [:]
+
+            self.next = next
+
+            self.extensions = [:]
+            self.groups = .init()
+        }
+    }
+}
+extension Unidoc.LinkerTables
+{
+    init(linker:consuming Unidoc.Linker)
+    {
+        let next:Next = .init(base: linker.current.id)
+        self.init(linker: linker, next: next)
+        self.readExtensions()
+    }
+}
+extension Unidoc.LinkerTables
+{
+    var current:Unidoc.Linker.Graph { self.linker.current }
+
+    private
+    var modules:ModuleView
+    {
+        .init(namespaces: self.current.namespaces,
+            cultures: self.current.cultures,
+            edition: self.current.id)
+    }
+
+    private mutating
+    func readExtensions()
+    {
+        for local:Int32 in self.current.decls.nodes.indices
+        {
+            let node:SymbolGraph.DeclNode = self.current.decls.nodes[local]
+            if  node.extensions.isEmpty
+            {
+                continue
+            }
+
+            guard
+            let extendee:Unidoc.Scalar = self.linker.current.scalars.decls[local]
+            else
+            {
+                let symbol:Symbol.Decl = self.linker.current.decls.symbols[local]
+                self.linker.diagnostics[nil] = DroppedExtensionsError.extending(symbol,
+                    count: node.extensions.count)
+                continue
+            }
+
+            self.extensions.add(extensions: node.extensions,
+                extending: extendee,
+                context: &self.linker)
+        }
+
+        self.peers = self.extensions.peers(in: self.linker.current.id)
+    }
+}
+extension Unidoc.LinkerTables
+{
+    borrowing
+    func linkConformingTypes() -> Unidoc.Linker.Table<Unidoc.Conformers>
+    {
+        var conformingTypes:Unidoc.Linker.Table<Unidoc.Conformers> = [:]
+
+        for (id, `extension`):(Unidoc.ExtensionSignature, Unidoc.Extension) in self.extensions
+        {
+            guard
+            let extendedType:SymbolGraph.Decl = self.linker[decl: id.extendee]
+            else
+            {
+                continue
+            }
+            /// A lot of C types have `Equatable` and `Hashable` conformances, but we don’t
+            /// care about them.
+            guard case .swift = extendedType.language
+            else
+            {
+                continue
+            }
+            for conformance:Unidoc.Scalar in `extension`.conformances
+            {
+                conformingTypes[.conforms(to: conformance, in: id.culture)].append(
+                    conformer: id.extendee,
+                    where: id.conditions.constraints)
+            }
+        }
+
+        return conformingTypes
+    }
+
+    /// This **must** be called before ``linkCultures``!
+    mutating
+    func linkProducts() -> [Unidoc.ProductVertex]
+    {
+        var productVertices:[Unidoc.ProductVertex] = []
+            productVertices.reserveCapacity(self.current.metadata.products.count)
+
+        //  Create a synthetic topic containing all the products. This will become a “See Also”
+        //  for their product pages.
+        var products:Unidoc.CuratorGroup = .init(id: self.next(.curator),
+            scope: self.current.id.global)
+
+        for (p, product):(Int32, SymbolGraph.Product) in zip(
+            self.current.metadata.products.indices,
+            self.current.metadata.products)
+        {
+            var constituents:[Unidoc.Scalar] = product.cultures
+                .sorted
+            {
+                self.current.namespaces[$0] < self.current.namespaces[$1]
+            }
+                .map
+            {
+                self.current.id + $0
+            }
+
+            for product:Symbol.Product in product.dependencies.sorted()
+            {
+                if  let package:Unidoc.Linker.Graph = self.linker[product.package],
+                    let q:Unidoc.Scalar = package.scalars.products[product.name]
+                {
+                    constituents.append(q)
+                }
+            }
+
+            let product:Unidoc.ProductVertex = .init(id: self.current.id + p,
+                constituents: constituents,
+                symbol: product.name,
+                type: product.type,
+                group: products.id)
+
+            products.items.append(product.id)
+            productVertices.append(product)
+        }
+
+        //  Create a synthetic topic containing all the cultures. This will become a “See Also”
+        //  for their module pages, unless they belong to a custom topic group.
+        let cultures:Unidoc.CuratorGroup = .init(id: self.next(.curator),
+            scope: self.current.id.global,
+            items: self.current.cultures.indices.sorted
+            {
+                self.current.namespaces[$0] <
+                self.current.namespaces[$1]
+            }
+                .map
+            {
+                self.current.id + $0
+            })
+
+        self.groups.curators.append(products)
+        self.groups.curators.append(cultures)
+
+        for c:Int in self.current.cultures.indices
+        {
+            self.group[c * .module] = cultures.id
+        }
+
+        return productVertices
+    }
+
+    mutating
+    func linkCurations()
+    {
+        for topic:[Int32] in self.current.curation
+        {
+            let items:[Unidoc.Scalar] = topic.compactMap
+            {
+                //  This is needed to correctly handle the case where a topic contains a
+                //  reference to a feature inherited from a different package.
+                if  case SymbolGraph.Plane.decl? = .of($0)
+                {
+                    self.current.scalars.decls[$0]
+                }
+                else if
+                    let c:Int = $0 / .module
+                {
+                    self.current.scalars.modules[c]
+                }
+                else
+                {
+                    self.current.id + $0
+                }
+            }
+            if  items.isEmpty
+            {
+                continue
+            }
+            let group:Unidoc.CuratorGroup = .init(id: self.next(.curator), items: items)
+            for item:Int32 in topic
+            {
+                //  TODO: diagnose overlapping topics
+                self.group[item] = group.id
+            }
+
+            self.groups.curators.append(group)
+        }
+    }
+    mutating
+    func linkIntrinsics()
+    {
+        for module:ModuleContext in self.modules
+        {
+            for decls:SymbolGraph.Namespace in module.culture.namespaces
+            {
+                for (d, node):(Int32, SymbolGraph.DeclNode) in zip(decls.range,
+                    self.current.decls.nodes[decls.range])
+                {
+                    //  Should always succeed!
+                    guard
+                    let owner:Unidoc.Scalar = self.current.scalars.decls[d],
+                    let decl:SymbolGraph.Decl = node.decl
+                    else
+                    {
+                        continue
+                    }
+
+                    let intrinsicGroup:Unidoc.Group = self.next(.intrinsic)
+                    let intrinsicCount:Int = decl.requirements.count + decl.inhabitants.count
+                    var intrinsicMembers:[Unidoc.Scalar] = []
+                        intrinsicMembers.reserveCapacity(intrinsicCount)
+
+                    //  https://forums.swift.org/t/efficiently-chaining-two-arrays/69551
+                    for local:Int32 in [decl.requirements, decl.inhabitants].joined()
+                    {
+                        //  This should always succeed, since requirements and inhabitants
+                        //  should appear in the same package (and the same module!) as the
+                        //  protocol/enum that declares them.
+                        guard
+                        let id:Unidoc.Scalar = self.current.scalars.decls[local]
+                        else
+                        {
+                            continue
+                        }
+
+                        self.peers[local] = intrinsicGroup
+                        intrinsicMembers.append(id)
+                    }
+
+                    if !intrinsicMembers.isEmpty
+                    {
+                        self.groups.intrinsics.append(.init(id: intrinsicGroup,
+                            culture: module.id,
+                            scope: owner,
+                            items: self.linker.sort(intrinsicMembers,
+                                by: Unidoc.SemanticPriority.self)))
+                    }
+                }
+            }
+        }
+    }
+
+    /// This **must** be called after ``linkProducts``!
+    mutating
+    func linkArticles() -> [Unidoc.ArticleVertex]
+    {
+        self.modules.reduce(into: [])
+        {
+            if  let range:ClosedRange<Int32> = $1.culture.articles
+            {
+                for local:Int32 in range
+                {
+                    $0.append(self.linkArticle(at: local, under: $1))
+                }
+            }
+        }
+    }
+
+    mutating
+    func linkDecls() -> [Unidoc.DeclVertex]
+    {
+        self.modules.reduce(into: [])
+        {
+            var miscellaneous:[Unidoc.Scalar] = []
+
+            //  Create decl records.
+            for colony:SymbolGraph.Namespace in $1.culture.namespaces
+            {
+                let name:Symbol.Module = self.current.namespaces[colony.index]
+
+                guard
+                let id:Unidoc.Scalar = self.current.scalars.modules[colony.index]
+                else
+                {
+                    self.linker.diagnostics[nil] = DroppedExtensionsError.extending(name,
+                        count: colony.range.count)
+                    continue
+                }
+
+                let namespace:ModuleNamespace = .init(
+                    culture: $1.id,
+                    colony: id,
+                    symbol: name)
+
+                for local:Int32 in colony.range
+                {
+                    guard
+                    let vertex:Unidoc.DeclVertex = self.linkDecl(at: local, under: namespace)
+                    else
+                    {
+                        continue
+                    }
+
+                    if  case nil = vertex.group,
+                        vertex.scope.isEmpty,
+                        vertex.symbol.language == .s || vertex.phylum.isTypelike
+                    {
+                        miscellaneous.append(vertex.id)
+                    }
+
+                    $0.append(vertex)
+                }
+            }
+
+            if !miscellaneous.isEmpty
+            {
+                //  Create top-level polygon.
+                self.groups.curators.append(.init(id: self.next(.curator),
+                    scope: $1.id,
+                    items: self.linker.sort(miscellaneous, by: Unidoc.SemanticPriority.self)))
+            }
+        }
+    }
+    mutating
+    func linkCultures() -> [Unidoc.CultureVertex]
+    {
+        self.modules.map
+        {
+            var vertex:Unidoc.CultureVertex = .init(id: $0.id,
+                module: $0.culture.module,
+                group: $0.culture.article?.footer == .omit
+                    ? nil
+                    : self.group[$0.id.citizen])
+
+            if  let article:SymbolGraph.Article = $0.culture.article
+            {
+                //  No sense customizing the headline if there is no article.
+                vertex.headline = $0.culture.headline
+                vertex.readme = article.file.map { self.current.id + $0 }
+                (vertex.overview, vertex.details) = self.linker.link(article: article)
+            }
+
+            return vertex
+        }
+    }
+}
+extension Unidoc.LinkerTables
+{
+    private mutating
+    func linkArticle(at local:Int32, under namespace:ModuleContext) -> Unidoc.ArticleVertex
+    {
+        let node:SymbolGraph.ArticleNode = self.current.articles.nodes[local]
+        let symbol:Symbol.Article = self.current.articles.symbols[local]
+        let id:Unidoc.Scalar = self.current.id + local
+        /// >   Note:
+        /// Constructing the stem by joining the `namespace.symbol` with the `symbol.path`
+        /// should result in the same stem that you would obtain by just copying the raw
+        /// article symbol itself, because articles should never migrate between modules.
+        /// However, we tend to emphasize the distinction between module culture and module
+        /// namespace elsewhere, so we will continue to construct the stem pedantically.
+        var vertex:Unidoc.ArticleVertex = .init(id: id,
+            stem: .article(namespace.symbol, path: symbol.path),
+            culture: namespace.id,
+            readme: node.article.file.map { self.current.id + $0 },
+            headline: node.headline,
+            group: node.article.footer == .omit ? nil : self.group[local])
+
+        (vertex.overview, vertex.details) = self.linker.link(article: node.article)
+
+        return vertex
+    }
+
+    /// Returns a list of uncategorized top-level declarations.
+    private mutating
+    func linkDecl(at local:Int32, under namespace:ModuleNamespace) -> Unidoc.DeclVertex?
+    {
+        let symbol:Symbol.Decl = self.current.decls.symbols[local]
+        let node:SymbolGraph.DeclNode = self.current.decls.nodes[local]
+
+        /// Does this declaration belong to a topic?
+        let group:Unidoc.Group? = node.decl?.article?.footer == .omit ? nil : self.group[local]
+        /// Does this declaration have peers?
+        let peers:Unidoc.Group? = self.peers[local]
+        /// Is this declaration a top-level member of its module?
+        /// (Being a top-level declaration is the only way this can be nil)
+        let scope:Unidoc.Scalar? = self.current.scope(of: local)
+
+        //  Ceremonial unwraps, should always succeed since we are only iterating
+        //  over module ranges.
+        guard
+        let decl:SymbolGraph.Decl = node.decl,
+        let id:Unidoc.Scalar = self.current.scalars.decls[local]
+        else
+        {
+            return nil
+        }
+
+        let superforms:[Unidoc.Scalar] = decl.superforms.compactMap
+        {
+            self.current.scalars.decls[$0]
+        }
+        for s:Unidoc.Scalar in superforms
+        {
+            let unconditional:Unidoc.ExtensionConditions = .init(constraints: [],
+                culture: namespace.cultureOffset)
+
+            self.extensions[.extends(s, where: unconditional)].subforms.append(id)
+        }
+
+        var vertex:Unidoc.DeclVertex = .init(id: id,
+            flags: .init(
+                language: decl.language,
+                phylum: decl.phylum,
+                kinks: decl.kinks,
+                route: decl.route),
+            signature: decl.signature.map { self.current.scalars.decls[$0] },
+            symbol: symbol,
+            stem: .decl(namespace.symbol, decl.path, orientation: decl.phylum.orientation),
+            _requirements: [],
+            superforms: self.linker.sort(superforms, by: Unidoc.SemanticPriority.self),
+            namespace: namespace.colony,
+            culture: namespace.culture,
+            scope: scope.map { self.linker.expand($0) } ?? [],
+            renamed: decl.renamed.map { self.current.scalars.decls[$0] } ?? nil,
+            file: decl.location.map { self.current.id + $0.file },
+            position: decl.location?.position,
+            peers: peers,
+            group: group)
+
+        if  let article:SymbolGraph.Article = decl.article
+        {
+            (vertex.overview, vertex.details) = self.linker.link(article: article)
+            vertex.readme = article.file.map { self.current.id + $0 }
+        }
+
+        return vertex
+    }
+}

--- a/Sources/UnidocLinker/Unidoc.Mesh.Interior.swift
+++ b/Sources/UnidocLinker/Unidoc.Mesh.Interior.swift
@@ -75,7 +75,7 @@ extension Unidoc.Mesh.Interior
         let groups:Unidoc.Mesh.Groups
         let extensions:Unidoc.Linker.Table<Unidoc.Extension>
 
-        if  metadata.abi < .v(0, 10, 0)
+        if  metadata.abi < .v(0, 11, 0)
         {
             var tables:Unidoc.Linker.Tables = .init(context: consume linker)
 

--- a/Sources/UnidocLinker/Unidoc.Mesh.Interior.swift
+++ b/Sources/UnidocLinker/Unidoc.Mesh.Interior.swift
@@ -66,18 +66,48 @@ extension Unidoc.Mesh.Interior
                 symbolsLinked: symbols.linked),
             packages: pins.compactMap(\.?.package))
 
-        var tables:Unidoc.Linker.Tables = .init(context: consume linker)
+        let conformances:Unidoc.Linker.Table<Unidoc.Conformers>
+        let products:[Unidoc.ProductVertex]
+        let cultures:[Unidoc.CultureVertex]
 
-        let conformances:Unidoc.Linker.Table<Unidoc.Conformers> = tables.linkConformingTypes()
-        let products:[Unidoc.ProductVertex] = tables.linkProducts()
-        let cultures:[Unidoc.CultureVertex] = tables.linkCultures()
+        let articles:[Unidoc.ArticleVertex]
+        let decls:[Unidoc.DeclVertex]
+        let groups:Unidoc.Mesh.Groups
+        let extensions:Unidoc.Linker.Table<Unidoc.Extension>
 
-        let articles:[Unidoc.ArticleVertex] = tables.articles
-        let decls:[Unidoc.DeclVertex] = tables.decls
-        let groups:Unidoc.Mesh.Groups = tables.groups
-        let extensions:Unidoc.Linker.Table<Unidoc.Extension> = tables.extensions
+        if  metadata.abi < .v(0, 10, 0)
+        {
+            var tables:Unidoc.Linker.Tables = .init(context: consume linker)
 
-        linker = (consume tables).context
+            conformances = tables.linkConformingTypes()
+            products = tables.linkProducts()
+            cultures = tables.linkCultures()
+            articles = tables.articles
+            decls = tables.decls
+            groups = tables.groups
+            extensions = tables.extensions
+
+            linker = tables.context
+        }
+        else
+        {
+            var tables:Unidoc.LinkerTables = .init(linker: consume linker)
+
+            conformances = tables.linkConformingTypes()
+            products = tables.linkProducts()
+
+            tables.linkCurations()
+            tables.linkIntrinsics()
+
+            decls = tables.linkDecls()
+            articles = tables.linkArticles()
+            cultures = tables.linkCultures()
+
+            extensions = tables.extensions
+            groups = tables.groups
+
+            linker = tables.linker
+        }
 
         self.init(around: landingVertex,
             conformances: conformances,

--- a/Sources/UnidocLinker/Unidoc.Outline (ext).swift
+++ b/Sources/UnidocLinker/Unidoc.Outline (ext).swift
@@ -1,0 +1,61 @@
+import UnidocRecords
+
+extension Unidoc.Outline
+{
+    static func url(sanitizing url:String) -> Self
+    {
+        guard let colon:String.Index = url.firstIndex(of: ":"),
+        case "https" = url[..<colon]
+        else
+        {
+            return .url(url, safe: false)
+        }
+
+        //  Skip the two slashes.
+        guard let start:String.Index = url.index(colon, offsetBy: 3, limitedBy: url.endIndex),
+        case "//" = url[url.index(after: colon) ..< start]
+        else
+        {
+            return .url(url, safe: false)
+        }
+
+        let domain:Substring
+
+        if  let slash:String.Index = url[start...].firstIndex(of: "/")
+        {
+            domain = url[start ..< slash]
+        }
+        else
+        {
+            domain = url[start...]
+        }
+
+        let root:Substring
+        if  let j:String.Index = domain.lastIndex(of: "."),
+            let i:String.Index = domain[..<j].lastIndex(of: ".")
+        {
+            root = domain[domain.index(after: i)...]
+        }
+        else
+        {
+            root = domain
+        }
+
+        //  We will follow links to GitHub and reputable open-source indexes.
+        let safe:Bool = switch root
+        {
+        case "freebsd.org":     true
+        case "github.com":      true
+        case "ietf.org":        true
+        case "man7.org":        true
+        case "mozilla.org":     true
+        case "scala-lang.org":  true
+        case "swiftinit.org":   true
+        case "swift.org":       true
+        case "wikipedia.org":   true
+        default:                false
+        }
+
+        return .url(url, safe: safe)
+    }
+}


### PR DESCRIPTION
this new dynamic linker builds far fewer tables and uses less memory owing to the optimized symbol graph format introduced in Unidoc 0.19

in the short term, this duplicates some code; when we’ve replaced the obsolete symbol graphs we can get rid of the old dynamic linker code entirely