### PR TITLE
fix false-positive ambiguous link error, and add a regression test

### DIFF
--- a/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
+++ b/Sources/SymbolGraphBuilder/Builds/SSGC.Workspace.swift
@@ -54,17 +54,25 @@ extension SSGC.Workspace
     public
     func build(package build:SSGC.PackageBuild,
         with swift:SSGC.Toolchain,
+        validation:SSGC.ValidationBehavior = .ignoreErrors,
         clean:Bool = true) throws -> SymbolGraphObject<Void>
     {
-        try self.build(some: build, toolchain: swift, status: nil, clean: clean)
+        try self.build(some: build, toolchain: swift, 
+            status: nil, 
+            logger: .init(validation: validation, file: nil),
+            clean: clean)
     }
 
     public
     func build(special build:SSGC.StandardLibraryBuild,
         with swift:SSGC.Toolchain,
+        validation:SSGC.ValidationBehavior = .ignoreErrors,
         clean:Bool = true) throws -> SymbolGraphObject<Void>
     {
-        try self.build(some: build, toolchain: swift, status: nil, clean: clean)
+        try self.build(some: build, toolchain: swift, 
+            status: nil, 
+            logger: .init(validation: validation, file: nil),
+            clean: clean)
     }
 }
 extension SSGC.Workspace

--- a/Sources/SymbolGraphBuilderTests/Main.swift
+++ b/Sources/SymbolGraphBuilderTests/Main.swift
@@ -153,6 +153,17 @@ enum Main:TestMain, TestBattery
 
         #endif
 
+        if  let tests:TestGroup = tests / "Reexportation",
+            let _:SymbolGraphObject<Void> = (tests.do
+            {
+                try workspace.build(
+                    package: .local(project: "TestPackages" / "swift-exportation"),
+                    with: toolchain,
+                    validation: .failOnErrors)
+            })
+        {
+        }
+
         group:
         if  let tests:TestGroup = tests / "Local",
             let docs:SymbolGraphObject<Void> = (tests.do

--- a/TestPackages/swift-exportation/Package.swift
+++ b/TestPackages/swift-exportation/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package:Package = .init(name: "Swift Unidoc Exportation Tests",
+    products:
+    [
+        .library(name: "A", targets: ["A"]),
+        .library(name: "B", targets: ["B"]),
+    ],
+    targets:
+    [
+        .target(name: "_A"),
+        .target(name: "A", dependencies: ["_A"]),
+        .target(name: "B", dependencies: ["A"]),
+    ])

--- a/TestPackages/swift-exportation/Sources/A/exports.swift
+++ b/TestPackages/swift-exportation/Sources/A/exports.swift
@@ -1,0 +1,1 @@
+@_exported import _A

--- a/TestPackages/swift-exportation/Sources/B/docs.docc/Article.md
+++ b/TestPackages/swift-exportation/Sources/B/docs.docc/Article.md
@@ -1,0 +1,7 @@
+# Exportation tests 
+
+All of the following should be valid links:
+
+-  ``A``
+-  ``A.A``
+-  ``_A.A``

--- a/TestPackages/swift-exportation/Sources/_A/A.swift
+++ b/TestPackages/swift-exportation/Sources/_A/A.swift
@@ -1,0 +1,4 @@
+public
+enum A 
+{
+}


### PR DESCRIPTION
this fixes a regression that was introduced in 0.19.4 in which `@_exported` symbol paths would cause false-positive ambiguous link errors