### PR TITLE
Discriminate empty trailing parentheses

### DIFF
--- a/Sources/LinkResolution/UCF.Predicate.swift
+++ b/Sources/LinkResolution/UCF.Predicate.swift
@@ -5,12 +5,12 @@ extension UCF
     struct Predicate
     {
         let suffix:Selector.Suffix?
-        let hasEmptyTrailingParentheses:Bool
+        let seal:Selector.Seal?
 
-        init(suffix:Selector.Suffix?, hasEmptyTrailingParentheses:Bool)
+        init(suffix:Selector.Suffix?, seal:Selector.Seal?)
         {
             self.suffix = suffix
-            self.hasEmptyTrailingParentheses = hasEmptyTrailingParentheses
+            self.seal = seal
         }
     }
 }

--- a/Sources/LinkResolution/UCF.Predicate.swift
+++ b/Sources/LinkResolution/UCF.Predicate.swift
@@ -1,0 +1,16 @@
+import UCF 
+
+extension UCF
+{
+    struct Predicate
+    {
+        let suffix:Selector.Suffix?
+        let hasEmptyTrailingParentheses:Bool
+
+        init(suffix:Selector.Suffix?, hasEmptyTrailingParentheses:Bool)
+        {
+            self.suffix = suffix
+            self.hasEmptyTrailingParentheses = hasEmptyTrailingParentheses
+        }
+    }
+}

--- a/Sources/LinkResolution/UCF.ResolutionTable.Search.swift
+++ b/Sources/LinkResolution/UCF.ResolutionTable.Search.swift
@@ -7,14 +7,14 @@ extension UCF.ResolutionTable
     struct Search
     {
         private
-        let predicate:UCF.Selector.Suffix?
+        let predicate:UCF.Predicate
 
         private
         var selected:[Symbol.Decl: Overload]
         private
         var rejected:[Symbol.Decl: Overload]
 
-        init(matching predicate:UCF.Selector.Suffix?)
+        init(matching predicate:UCF.Predicate)
         {
             self.predicate = predicate
             self.selected = [:]
@@ -29,26 +29,16 @@ extension UCF.ResolutionTable.Search
     {
         //  Because of the way `@_exported` paths are represented in the search tree, it is 
         //  possible to encounter the same overload multiple times, due to namespace inference
-        if  let predicate:UCF.Selector.Suffix = self.predicate
+        for overload:Overload in candidates
         {
-            for overload:Overload in candidates
+            guard self.predicate ~= overload
+            else
             {
-                guard predicate ~= overload
-                else
-                {
-                    self.rejected[overload.id] = overload
-                    continue
-                }
+                self.rejected[overload.id] = overload
+                continue
+            }
 
-                self.selected[overload.id] = overload
-            }
-        }
-        else
-        {
-            for overload:Overload in candidates
-            {
-                self.selected[overload.id] = overload
-            }
+            self.selected[overload.id] = overload
         }
     }
 

--- a/Sources/LinkResolution/UCF.ResolutionTable.swift
+++ b/Sources/LinkResolution/UCF.ResolutionTable.swift
@@ -99,17 +99,16 @@ extension UCF.ResolutionTable
 extension UCF.ResolutionTable
 {
     public
-    func resolve(qualified path:UCF.Selector.Path,
-        matching suffix:UCF.Selector.Suffix?) -> UCF.Resolution<Overload>
+    func resolve(qualified:UCF.Selector) -> UCF.Resolution<Overload>
     {
-        var search:Search = .init(matching: suffix)
-        return self.resolve(qualified: path, with: &search)
+        var search:Search = .init(matching: qualified.predicate)
+        return self.resolve(qualified: qualified.path, with: &search)
     }
 
     func resolve(_ selector:UCF.Selector,
         in scope:UCF.ResolutionScope) -> UCF.Resolution<Overload>
     {
-        var search:Search = .init(matching: selector.suffix)
+        var search:Search = .init(matching: selector.predicate)
 
         if  case .relative = selector.base
         {

--- a/Sources/LinkResolution/UCF.ResolvableOverload.swift
+++ b/Sources/LinkResolution/UCF.ResolvableOverload.swift
@@ -15,14 +15,43 @@ extension UCF
 }
 extension UCF.ResolvableOverload
 {
-    static func ~= (suffix:UCF.Selector.Suffix, self:Self) -> Bool
+    static func ~= (predicate:UCF.Predicate, self:Self) -> Bool
     {
+        if  predicate.hasEmptyTrailingParentheses
+        {
+            switch self.phylum
+            {
+            case .actor:                    return false
+            case .associatedtype:           return false
+            case .case:                     return false
+            case .class:                    return false
+            case .deinitializer:            return false
+            case .enum:                     return false
+            case .func:                     break
+            case .initializer:              break
+            case .macro:                    break
+            case .operator:                 break
+            case .protocol:                 return false
+            case .struct:                   return false
+            case .subscript:                break
+            case .typealias:                return false
+            case .var:                      return false
+            }
+        }
+
+        guard 
+        let suffix:UCF.Selector.Suffix = predicate.suffix
+        else
+        {
+            return true
+        }
+
         switch suffix
         {
-        case .legacy(let filter, nil):  filter ~= self.phylum
-        case .legacy(_, let hash?):     hash == self.hash
-        case .hash(let hash):           hash == self.hash
-        case .filter(let filter):       filter ~= self.phylum
+        case .legacy(let filter, nil):      return filter ~= self.phylum
+        case .legacy(_, let hash?):         return hash == self.hash
+        case .hash(let hash):               return hash == self.hash
+        case .filter(let filter):           return filter ~= self.phylum
         }
     }
 }

--- a/Sources/LinkResolution/UCF.ResolvableOverload.swift
+++ b/Sources/LinkResolution/UCF.ResolvableOverload.swift
@@ -17,7 +17,30 @@ extension UCF.ResolvableOverload
 {
     static func ~= (predicate:UCF.Predicate, self:Self) -> Bool
     {
-        if  predicate.hasEmptyTrailingParentheses
+        if  case nil = predicate.seal
+        {
+            //  Macros are currently the only kind of declaration that *must* be spelled with 
+            //  trailing parentheses.
+            switch self.phylum
+            {
+            case .actor:                    break
+            case .associatedtype:           break
+            case .case:                     break
+            case .class:                    break
+            case .deinitializer:            break
+            case .enum:                     break
+            case .func:                     break
+            case .initializer:              break
+            case .macro:                    return false
+            case .operator:                 break
+            case .protocol:                 break
+            case .struct:                   break
+            case .subscript:                break
+            case .typealias:                break
+            case .var:                      break
+            }
+        }
+        else 
         {
             switch self.phylum
             {

--- a/Sources/LinkResolution/UCF.Selector (ext).swift
+++ b/Sources/LinkResolution/UCF.Selector (ext).swift
@@ -5,8 +5,7 @@ extension UCF.Selector
 {
     var predicate:UCF.Predicate 
     {
-        .init(suffix: self.suffix, 
-            hasEmptyTrailingParentheses: self.path.hasEmptyTrailingParentheses)
+        .init(suffix: self.suffix, seal: self.path.seal)
     }
 }
 //  TODO: this does not belong in this module

--- a/Sources/LinkResolution/UCF.Selector (ext).swift
+++ b/Sources/LinkResolution/UCF.Selector (ext).swift
@@ -1,6 +1,14 @@
 import FNV1
 import UCF
 
+extension UCF.Selector
+{
+    var predicate:UCF.Predicate 
+    {
+        .init(suffix: self.suffix, 
+            hasEmptyTrailingParentheses: self.path.hasEmptyTrailingParentheses)
+    }
+}
 //  TODO: this does not belong in this module
 extension UCF.Selector
 {

--- a/Sources/SymbolGraphLinker/Resolution/SSGC.OutlineResolver.swift
+++ b/Sources/SymbolGraphLinker/Resolution/SSGC.OutlineResolver.swift
@@ -144,13 +144,11 @@ extension SSGC.OutlineResolver
         else
         {
             return nil
-        }
+        } 
 
-        switch self.scopes.causalURLs.resolve(
-            qualified: translatable.path,
-            matching: translatable.suffix)
-        {
-        case .module(let module):
+        switch self.scopes.causalURLs.resolve(qualified: translatable)
+        { 
+        case .module(let module): 
             //  Unidoc linker doesn’t currently support `symbol` outlines that are not
             //  declarations, so for now we just synthesize a normal vertex outline.
             let text:SymbolGraph.OutlineText = .init(path: "\(module)", fragment: nil)

--- a/Sources/UCF/Codelinks/UCF.Selector.Path.swift
+++ b/Sources/UCF/Codelinks/UCF.Selector.Path.swift
@@ -9,12 +9,15 @@ extension UCF.Selector
         /// The index of the first visible component in this path.
         public
         var fold:Int
+        public
+        var hasEmptyTrailingParentheses:Bool
 
         @inlinable public
-        init(components:[String] = [], fold:Int = 0)
+        init(components:[String] = [], fold:Int = 0, hasEmptyTrailingParentheses:Bool = false)
         {
             self.components = components
             self.fold = fold
+            self.hasEmptyTrailingParentheses = hasEmptyTrailingParentheses
         }
     }
 }
@@ -114,6 +117,7 @@ extension UCF.Selector.Path
             case k?:
                 //  Special case: ignore empty trailing parentheses
                 self.components.append(String.init(string[i ..< j]))
+                self.hasEmptyTrailingParentheses = true
                 return string.index(after: k)
 
             case let k?:

--- a/Sources/UCF/Codelinks/UCF.Selector.Path.swift
+++ b/Sources/UCF/Codelinks/UCF.Selector.Path.swift
@@ -10,19 +10,25 @@ extension UCF.Selector
         public
         var fold:Int
         public
-        var hasEmptyTrailingParentheses:Bool
+        var seal:Seal?
 
         @inlinable public
-        init(components:[String] = [], fold:Int = 0, hasEmptyTrailingParentheses:Bool = false)
+        init(components:[String] = [], fold:Int = 0, seal:Seal? = nil)
         {
             self.components = components
             self.fold = fold
-            self.hasEmptyTrailingParentheses = hasEmptyTrailingParentheses
+            self.seal = seal
         }
     }
 }
 extension UCF.Selector.Path
 {
+    @inlinable public
+    var hasTrailingParentheses:Bool
+    {
+        self.seal != nil
+    }
+
     @inlinable public
     var visible:ArraySlice<String>
     {
@@ -117,10 +123,11 @@ extension UCF.Selector.Path
             case k?:
                 //  Special case: ignore empty trailing parentheses
                 self.components.append(String.init(string[i ..< j]))
-                self.hasEmptyTrailingParentheses = true
+                self.seal = .trailingParentheses
                 return string.index(after: k)
 
             case let k?:
+                self.seal = .trailingArguments
                 j = string.index(after: k)
             }
         }

--- a/Sources/UCF/Codelinks/UCF.Selector.Seal.swift
+++ b/Sources/UCF/Codelinks/UCF.Selector.Seal.swift
@@ -1,0 +1,9 @@
+extension UCF.Selector
+{
+    @frozen public
+    enum Seal:Equatable, Hashable, Sendable
+    {
+        case trailingParentheses
+        case trailingArguments
+    }
+}

--- a/Sources/UCF/Codelinks/UCF.Selector.swift
+++ b/Sources/UCF/Codelinks/UCF.Selector.swift
@@ -45,6 +45,11 @@ extension UCF.Selector:CustomStringConvertible
             string += component
         }
 
+        if  self.path.hasEmptyTrailingParentheses
+        {
+            string += "()"
+        }
+
         switch self.suffix
         {
         case nil:
@@ -281,8 +286,8 @@ extension UCF.Selector
 }
 extension UCF.Selector
 {
-    @inlinable public static
-    func equivalent(to doclink:Doclink) -> Self?
+    @inlinable public 
+    static func equivalent(to doclink:Doclink) -> Self?
     {
         if  doclink.absolute
         {

--- a/Sources/UCF/Codelinks/UCF.Selector.swift
+++ b/Sources/UCF/Codelinks/UCF.Selector.swift
@@ -45,7 +45,7 @@ extension UCF.Selector:CustomStringConvertible
             string += component
         }
 
-        if  self.path.hasEmptyTrailingParentheses
+        if  case .trailingParentheses? = self.path.seal
         {
             string += "()"
         }

--- a/Sources/UCFTests/Main.ParseCodelink.swift
+++ b/Sources/UCFTests/Main.ParseCodelink.swift
@@ -126,6 +126,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "init"])
                 tests.expect(link.path.visible ..? ["Real", "init"])
+                tests.expect(true: link.path.hasEmptyTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "EmptyTrailingComponent",

--- a/Sources/UCFTests/Main.ParseCodelink.swift
+++ b/Sources/UCFTests/Main.ParseCodelink.swift
@@ -21,6 +21,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Unicode", "Scalar", "value"])
                 tests.expect(link.path.visible ..? ["Unicode", "Scalar", "value"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "SlashDot",
@@ -29,6 +30,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Unicode", "Scalar", "value"])
                 tests.expect(link.path.visible ..? ["Scalar", "value"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "DotSlash",
@@ -37,6 +39,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Unicode", "Scalar", "value"])
                 tests.expect(link.path.visible ..? ["value"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "SlashSlash",
@@ -45,6 +48,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Unicode", "Scalar", "value"])
                 tests.expect(link.path.visible ..? ["value"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "SingleCharacter",
@@ -53,6 +57,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["x"])
                 tests.expect(link.path.visible ..? ["x"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
 
@@ -62,6 +67,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "..(_:_:)"])
                 tests.expect(link.path.visible ..? ["Real", "..(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Real" / "2",
@@ -70,6 +76,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "..(_:_:)"])
                 tests.expect(link.path.visible ..? ["..(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Real" / "3",
@@ -78,6 +85,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "...(_:_:)"])
                 tests.expect(link.path.visible ..? ["Real", "...(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Real" / "4",
@@ -86,6 +94,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "...(_:_:)"])
                 tests.expect(link.path.visible ..? ["...(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Real" / "5",
@@ -94,6 +103,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "/(_:_:)"])
                 tests.expect(link.path.visible ..? ["Real", "/(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Real" / "6",
@@ -102,6 +112,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "/(_:_:)"])
                 tests.expect(link.path.visible ..? ["/(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Real" / "7",
@@ -110,6 +121,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "./.(_:_:)"])
                 tests.expect(link.path.visible ..? ["Real", "./.(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Real" / "8",
@@ -118,6 +130,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "./.(_:_:)"])
                 tests.expect(link.path.visible ..? ["./.(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "EmptyTrailingParentheses",
@@ -126,7 +139,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "init"])
                 tests.expect(link.path.visible ..? ["Real", "init"])
-                tests.expect(true: link.path.hasEmptyTrailingParentheses)
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "EmptyTrailingComponent",
@@ -135,6 +148,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Real", "init"])
                 tests.expect(link.path.visible ..? ["Real", "init"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "DivisionOperator",
@@ -143,6 +157,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["/(_:_:)"])
                 tests.expect(link.path.visible ..? ["/(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "CustomOperator",
@@ -151,6 +166,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["/-/(_:_:)"])
                 tests.expect(link.path.visible ..? ["/-/(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "ClosedRangeOperator",
@@ -159,6 +175,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["...(_:_:)"])
                 tests.expect(link.path.visible ..? ["...(_:_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
         }
@@ -169,6 +186,7 @@ extension Main.ParseCodelink:TestBattery
             {
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Fake"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .filter(.enum))
             }
             if  let tests:TestGroup = tests / "Fake" / "UncannyHash",
@@ -178,6 +196,7 @@ extension Main.ParseCodelink:TestBattery
 
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Fake"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .hash(hash))
             }
             if  let tests:TestGroup = tests / "Fake" / "ClassVar",
@@ -185,6 +204,7 @@ extension Main.ParseCodelink:TestBattery
             {
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Fake", "max"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .filter(.class_var))
             }
         }
@@ -196,6 +216,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "Color"])
                 tests.expect(link.path.visible ..? ["Color"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Filter",
@@ -204,6 +225,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "Color"])
                 tests.expect(link.path.visible ..? ["Color"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .filter(.enum))
             }
             if  let tests:TestGroup = tests / "FilterInterior",
@@ -212,6 +234,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "Color"])
                 tests.expect(link.path.visible ..? ["Color"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "FilterLegacy",
@@ -220,6 +243,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "Color"])
                 tests.expect(link.path.visible ..? ["Color"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .legacy(.class, nil))
             }
             if  let tests:TestGroup = tests / "FilterAndHash",
@@ -230,6 +254,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "Color"])
                 tests.expect(link.path.visible ..? ["Color"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .legacy(.struct, hash))
             }
             if  let tests:TestGroup = tests / "Hash",
@@ -240,6 +265,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "update(_:)"])
                 tests.expect(link.path.visible ..? ["update(_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .hash(hash))
             }
             if  let tests:TestGroup = tests / "Hash" / "Minus",
@@ -250,6 +276,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "-(_:)"])
                 tests.expect(link.path.visible ..? ["-(_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .hash(hash))
             }
             if  let tests:TestGroup = tests / "Hash" / "Slinging" / "Slasher",
@@ -260,6 +287,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .relative)
                 tests.expect(link.path.components ..? ["Sloth", "/(_:)"])
                 tests.expect(link.path.visible ..? ["/(_:)"])
+                tests.expect(true: link.path.hasTrailingParentheses)
                 tests.expect(link.suffix ==? .hash(hash))
             }
         }
@@ -271,6 +299,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .qualified)
                 tests.expect(link.path.components ..? ["Swift"])
                 tests.expect(link.path.visible ..? ["Swift"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Hidden",
@@ -279,6 +308,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .qualified)
                 tests.expect(link.path.components ..? ["Swift", "Int"])
                 tests.expect(link.path.visible ..? ["Int"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "Visible",
@@ -287,6 +317,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .qualified)
                 tests.expect(link.path.components ..? ["Swift", "Int"])
                 tests.expect(link.path.visible ..? ["Swift", "Int"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
             if  let tests:TestGroup = tests / "EmptyTrailingComponent",
@@ -295,6 +326,7 @@ extension Main.ParseCodelink:TestBattery
                 tests.expect(link.base ==? .qualified)
                 tests.expect(link.path.components ..? ["Swift", "Int"])
                 tests.expect(link.path.visible ..? ["Swift", "Int"])
+                tests.expect(false: link.path.hasTrailingParentheses)
                 tests.expect(nil: link.suffix)
             }
         }


### PR DESCRIPTION
trailing parentheses in codelink spelling will now exclude all declarations that could never be written with trailing parentheses, and the lack of trailing parentheses will now exclude macros specifically from link resolution