### PR TITLE
Deduplicate macro synthesized decls

### DIFF
--- a/Sources/SymbolGraphLinker/SSGC.Linker.Tables.swift
+++ b/Sources/SymbolGraphLinker/SSGC.Linker.Tables.swift
@@ -93,13 +93,12 @@ extension SSGC.Linker.Tables
         } (&self.articles[article])
     }
 
-    /// Indexes the given declaration and appends it to the symbol graph.
+    /// Indexes the given declaration and appends it to the symbol graph if and only if it has
+    /// not already been indexed. Returns nil if the declaration has already been indexed.
     ///
     /// This function only populates basic information (flags and path) about the declaration,
     /// the rest should only be added after completing a full pass over all the declarations and
     /// extensions.
-    ///
-    /// This function checks for duplicates.
     mutating
     func allocate(decl:SSGC.Decl, language:Phylum.Language) -> Int32?
     {

--- a/Sources/SymbolGraphLinker/SSGC.Linker.Tables.swift
+++ b/Sources/SymbolGraphLinker/SSGC.Linker.Tables.swift
@@ -99,20 +99,28 @@ extension SSGC.Linker.Tables
     /// the rest should only be added after completing a full pass over all the declarations and
     /// extensions.
     ///
-    /// This function doesn’t check for duplicates.
+    /// This function checks for duplicates.
     mutating
-    func allocate(decl:SSGC.Decl, language:Phylum.Language) -> Int32
+    func allocate(decl:SSGC.Decl, language:Phylum.Language) -> Int32?
     {
-        let vertex:SymbolGraph.Decl = .init(language: language,
-            phylum: decl.phylum,
-            kinks: decl.kinks,
-            path: decl.path)
+        {
+            guard case nil = $0
+            else
+            {
+                return nil
+            }
 
-        let scalar:Int32 = self.graph.decls.append(.init(decl: vertex),
-            id: decl.id)
+            let vertex:SymbolGraph.Decl = .init(language: language,
+                phylum: decl.phylum,
+                kinks: decl.kinks,
+                path: decl.path)
 
-        self.decls[decl.id] = scalar
-        return scalar
+            let scalar:Int32 = self.graph.decls.append(.init(decl: vertex),
+                id: decl.id)
+            $0 = scalar
+            return scalar
+
+        } (&self.decls[decl.id])
     }
 
     /// Indexes the declaration extended by the given extension and appends the (empty)

--- a/Sources/SymbolGraphLinker/SSGC.Linker.swift
+++ b/Sources/SymbolGraphLinker/SSGC.Linker.swift
@@ -266,7 +266,7 @@ extension SSGC.Linker
             else
             {
                 self.tables.diagnostics[nil] = .warning("""
-                    Declaration '\($0.path)' was synthesized by multiple modules in this
+                    Declaration '\($0.path)' was synthesized by multiple modules in this \
                     package and only one copy will be kept
                     """)
                 return false

--- a/Sources/SymbolGraphLinker/SSGC.Linker.swift
+++ b/Sources/SymbolGraphLinker/SSGC.Linker.swift
@@ -245,7 +245,17 @@ extension SSGC.Linker
         var scalars:(first:Int32, last:Int32)? = nil
         for decl:SSGC.Decl in decls
         {
+            guard
             let scalar:Int32 = self.tables.allocate(decl: decl, language: language)
+            else
+            {
+                self.tables.diagnostics[nil] = .warning("""
+                    Declaration '\(decl.path)' was synthesized by multiple modules in this
+                    package and only one copy will be kept
+                    """)
+                continue
+            }
+
             switch scalars
             {
             case  nil:              scalars = (scalar, scalar)

--- a/Sources/SymbolGraphLinker/SSGC.Linker.swift
+++ b/Sources/SymbolGraphLinker/SSGC.Linker.swift
@@ -200,26 +200,40 @@ extension SSGC.Linker
         as language:Phylum.Language,
         at offset:Int)
     {
-        let destinations:[SymbolGraph.Namespace] = declarations.map
+        let destinations:
+        [(
+            allocated:SymbolGraph.Namespace,
+            qualifier:Symbol.Module,
+            decls:[SSGC.Decl]
+        )] = declarations.reduce(into: [])
         {
-            .init(
-                range: self.allocate(decls: $0.decls, language: language),
-                index: self.tables.intern($0.id))
+            guard
+            let (range, decls):(ClosedRange<Int32>, [SSGC.Decl]) = self.allocate(
+                deduplicating: $1.decls,
+                language: language)
+            else
+            {
+                return
+            }
+
+            let allocated:SymbolGraph.Namespace = .init(
+                range: range,
+                index: self.tables.intern($1.id))
+
+            $0.append((allocated, $1.id, decls))
         }
         ;
         {
-            $0.reserveCapacity(destinations.reduce(0) { $0 + $1.range.count })
+            $0.reserveCapacity(destinations.reduce(0) { $0 + $1.allocated.range.count })
 
-            for (namespace, destination):
-                ((id:Symbol.Module, decls:[SSGC.Decl]), SymbolGraph.Namespace) in zip(
-                declarations,
-                destinations)
+            for (allocated, qualifier, decls):
+                (SymbolGraph.Namespace, Symbol.Module, [SSGC.Decl]) in destinations
             {
-                for (i, decl):(Int32, SSGC.Decl) in zip(destination.range, namespace.decls)
+                for (i, decl):(Int32, SSGC.Decl) in zip(allocated.range, decls)
                 {
                     let hash:FNV24 = .decl(decl.id)
                     //  Make the decl visible to codelink resolution.
-                    self.tables.packageLinks[namespace.id, decl.path].append(.init(
+                    self.tables.packageLinks[qualifier, decl.path].append(.init(
                         phylum: decl.phylum,
                         decl: i,
                         heir: nil,
@@ -228,32 +242,34 @@ extension SSGC.Linker
                         id: decl.id))
                     //  Assign the decl a URI, and record the decl’s hash
                     //  so we will know if it has a hash collision.
-                    self.router[namespace.id, decl.path, decl.phylum][hash, default: []]
+                    self.router[qualifier, decl.path, decl.phylum][hash, default: []]
                         .append(i)
 
-                    $0.append((decl, i, namespace.id))
+                    $0.append((decl, i, qualifier))
                 }
             }
         } (&self.contexts[offset].decls)
 
-        self.tables.graph.cultures[offset].namespaces = destinations
+        self.tables.graph.cultures[offset].namespaces = destinations.map(\.allocated)
     }
 
     private mutating
-    func allocate(decls:[SSGC.Decl], language:Phylum.Language) -> ClosedRange<Int32>
+    func allocate(
+        deduplicating decls:consuming [SSGC.Decl],
+        language:Phylum.Language) -> (ClosedRange<Int32>, [SSGC.Decl])?
     {
         var scalars:(first:Int32, last:Int32)? = nil
-        for decl:SSGC.Decl in decls
+        let kept:[SSGC.Decl] = decls.filter
         {
             guard
-            let scalar:Int32 = self.tables.allocate(decl: decl, language: language)
+            let scalar:Int32 = self.tables.allocate(decl: $0, language: language)
             else
             {
                 self.tables.diagnostics[nil] = .warning("""
-                    Declaration '\(decl.path)' was synthesized by multiple modules in this
+                    Declaration '\($0.path)' was synthesized by multiple modules in this
                     package and only one copy will be kept
                     """)
-                continue
+                return false
             }
 
             switch scalars
@@ -261,14 +277,17 @@ extension SSGC.Linker
             case  nil:              scalars = (scalar, scalar)
             case (let first, _)?:   scalars = (first,  scalar)
             }
+
+            return true
         }
+
         if  case (let first, let last)? = scalars
         {
-            return first ... last
+            return (first ... last, kept)
         }
         else
         {
-            fatalError("cannot allocate empty declaration array")
+            return nil
         }
     }
 


### PR DESCRIPTION
there is some kind of bug in lib/SymbolGraphGen that causes macro-synthesized declarations to *only* appear as `@_exported` symbols

Unidoc cannot correct this issue, but this PR makes it so that these declarations only occur once per symbol graph