### PR TITLE
raise guaranteed disk space to 6GB

### DIFF
--- a/Sources/UnidocClient/Unidoc.Client.swift
+++ b/Sources/UnidocClient/Unidoc.Client.swift
@@ -138,14 +138,14 @@ extension Unidoc.Client<HTTP.Client2>
         {
             //  Ensure the cache directory exists, solely for checking free space.
             try cache.directory.create()
-            //  If there is less than 2GB of free space on the current file system, and we
+            //  If there is less than 6GB of free space on the current file system, and we
             //  are using a manually-managed SwiftPM cache, we should clear it.
             let stats:FileSystemStats = try .containing(path: cache)
             let space:UInt = stats.blocksFreeForUnprivileged * stats.blockSize
 
             print("Free space available: \(space / 1_000_000) MB")
 
-            if  space < 2_000_000_000
+            if  space < 6_000_000_000
             {
                 try cache.directory.remove()
             }


### PR DESCRIPTION
it seems the Unidoc build harness only clears the SwiftPM cache if there is less than 2GB of free space available, which is far too low for many projects, so this raises the hard coded value to 6GB

long term, this needs to become configurable, and we also need to migrate the Swiftinit builders to larger hosts, as the 6GB threshold means the SwiftPM cache will be cleared on virtually every run.