### PR TITLE
enable type signature disambiguation for `var`s

### DIFF
--- a/Sources/MarkdownPluginSwift/Signatures/SignatureSyntax.AbridgedVisitor.swift
+++ b/Sources/MarkdownPluginSwift/Signatures/SignatureSyntax.AbridgedVisitor.swift
@@ -15,9 +15,4 @@ extension SignatureSyntax.AbridgedVisitor:SignatureVisitor
     {
         .init(syntax: parameter, type: type)
     }
-
-    mutating
-    func register(returns:TypeSyntax)
-    {
-    }
 }

--- a/Sources/MarkdownPluginSwift/Signatures/SignatureSyntax.ExpandedVisitor.swift
+++ b/Sources/MarkdownPluginSwift/Signatures/SignatureSyntax.ExpandedVisitor.swift
@@ -33,7 +33,9 @@ extension SignatureSyntax.ExpandedVisitor:SignatureVisitor
         inputs.append(autographer.autograph)
         return .init(syntax: parameter)
     }
-
+}
+extension SignatureSyntax.ExpandedVisitor
+{
     mutating
     func register(returns:TypeSyntax)
     {
@@ -50,9 +52,7 @@ extension SignatureSyntax.ExpandedVisitor:SignatureVisitor
             self.register(output: element.type)
         }
     }
-}
-extension SignatureSyntax.ExpandedVisitor
-{
+
     private mutating
     func register(output:TypeSyntax)
     {

--- a/Sources/MarkdownPluginSwift/Signatures/SignatureVisitor.swift
+++ b/Sources/MarkdownPluginSwift/Signatures/SignatureVisitor.swift
@@ -6,7 +6,4 @@ protocol SignatureVisitor
 
     mutating
     func register(parameter:FunctionParameterSyntax, type:SignatureParameterType) -> Parameter
-
-    mutating
-    func register(returns:TypeSyntax)
 }

--- a/Sources/MarkdownPluginSwiftTests/Autographs.swift
+++ b/Sources/MarkdownPluginSwiftTests/Autographs.swift
@@ -86,6 +86,36 @@ struct Autographs
     }
 
     @Test mutating
+    func Var1()
+    {
+        let decl:String = "static var x: (String)? { get }"
+        let _:Signature<Never>.Expanded = .init(decl, landmarks: &self.landmarks)
+
+        #expect(self.landmarks.inputs == [])
+        #expect(self.landmarks.output == ["String?"])
+    }
+
+    @Test mutating
+    func Var2()
+    {
+        let decl:String = "static var x: (T?, Set<T>) { get set }"
+        let _:Signature<Never>.Expanded = .init(decl, landmarks: &self.landmarks)
+
+        #expect(self.landmarks.inputs == [])
+        #expect(self.landmarks.output == ["T?", "Set<T>"])
+    }
+
+    @Test mutating
+    func Var3()
+    {
+        let decl:String = "var x: (Int, Int) -> (Int) -> Int"
+        let _:Signature<Never>.Expanded = .init(decl, landmarks: &self.landmarks)
+
+        #expect(self.landmarks.inputs == [])
+        #expect(self.landmarks.output == ["(Int,Int)->(Int)->Int"])
+    }
+
+    @Test mutating
     func SomeAndAnyTypes()
     {
         let decl:String = """

--- a/Sources/SymbolGraphParts/Vertices/SymbolGraphPart.Vertex.swift
+++ b/Sources/SymbolGraphParts/Vertices/SymbolGraphPart.Vertex.swift
@@ -81,14 +81,14 @@ extension SymbolGraphPart.Vertex
     {
         /// We will amend the actual phylum later in this function, but none of the amendments
         /// should affect the overloadability of the symbol.
-        let isDirectlyOverloadable:Bool
+        let isOverloadable:Bool
         if  case .decl(let decl) = phylum
         {
-            isDirectlyOverloadable = decl.isDirectlyOverloadable
+            isOverloadable = decl.isOverloadable
         }
         else
         {
-            isDirectlyOverloadable = false
+            isOverloadable = false
         }
         /// Static `Self` can appear in more places than just where `isDirectlyOverloadable`,
         /// but it will only be used if that is also true, so there is no point in computing it
@@ -111,7 +111,7 @@ extension SymbolGraphPart.Vertex
                 sugarDictionary: .sSD,
                 sugarArray: .sSa,
                 sugarOptional: .sSq,
-                desugarSelf: isDirectlyOverloadable
+                desugarSelf: isOverloadable
                     ? path.prefixFormatted(inserting: generics.parameters)
                     : nil,
                 landmarks: &landmarks)
@@ -173,7 +173,7 @@ extension SymbolGraphPart.Vertex
             final: landmarks.keywords.final,
             extension: `extension`,
             signature: signature,
-            autograph: isDirectlyOverloadable
+            autograph: isOverloadable
                 ? .init(inputs: landmarks.inputs, output: landmarks.output)
                 : nil,
             path: simplified,

--- a/Sources/Symbols/Declarations/Phylum.Decl.swift
+++ b/Sources/Symbols/Declarations/Phylum.Decl.swift
@@ -46,12 +46,15 @@ extension Phylum.Decl
     }
 
     @inlinable public
-    var isDirectlyOverloadable:Bool
+    var isOverloadable:Bool
     {
         switch self
         {
         case .actor:            false
         case .associatedtype:   false
+        //  No, `case` is not overloadable, even though it is function-like. It would never make
+        //  sense to try and disambiguate a `case` by type signature instead of using the
+        //  `[case]` disambiguator.
         case .case:             false
         case .class:            false
         case .deinitializer:    false
@@ -64,7 +67,9 @@ extension Phylum.Decl
         case .struct:           false
         case .subscript:        true
         case .typealias:        false
-        case .var:              false
+        //  Yes, `var` is overloadable! The most common example is `static var _:Self { get }`,
+        //  with different overloads for different generic constraints.
+        case .var:              true
         }
     }
     /// Indicates if the declaration is typelike. This is not the same as ``orientation``!


### PR DESCRIPTION
`var` can now be disambiguated! its type annotation can be specified as a “return type” (even if it is stored), and this is useful for choosing among multiple `static var _:Self { get }` overloads.