### PR TITLE
fix #386

### DIFF
--- a/Sources/UnidocUI/Page contexts/Unidoc.IdentifiablePageContext.swift
+++ b/Sources/UnidocUI/Page contexts/Unidoc.IdentifiablePageContext.swift
@@ -36,14 +36,9 @@ extension Unidoc
         {
             let packages:PackageContext = .init(principal: principal.id.package,
                 metadata: packages)
-            let media:PackageMedia
 
-            if  let override:PackageMedia = packages.principal?.media
-            {
-                media = override
-            }
-            else if
-                let repo:PackageRepo = packages.principal?.repo
+            var media:PackageMedia = packages.principal?.media ?? .init()
+            if  let repo:PackageRepo = packages.principal?.repo
             {
                 let ref:String = principal.refname ?? repo.master ?? "master"
                 let path:String
@@ -52,12 +47,8 @@ extension Unidoc
                 case .github(let origin):   path = "/\(origin.owner)/\(origin.name)/\(ref)"
                 }
 
-                media = .init(prefix: "https://raw.githubusercontent.com\(path)",
-                    webp: "https://media.githubusercontent.com/media\(path)")
-            }
-            else
-            {
-                media = .init()
+                media.prefix = media.prefix ?? "https://raw.githubusercontent.com\(path)"
+                media.webp = media.webp ?? "https://media.githubusercontent.com/media\(path)"
             }
 
             self.canonical = canonical


### PR DESCRIPTION
the bug here, *which only occurs in production* (yikes!) was that we had an optionally-chained

```swift
if  let media:PackageMedia = package?.media
{
}
```

but `PackageMedia` itself is a non-optional struct of optionals, so this unwrap always succeeds, which causes the production server to always believe it is serving local development media.

this bug was probably introduced when we made `PackageMedia` non-optional, to avoid having meaningless nested optionals. this meant it became possible to have completely empty `PackageMedia` instances, but code that checked if this field was populated would use the empty structures instead of going down the production media path.