### PR TITLE
add git commit date and SHA-1 hash to volume metadata

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7bb6ebf87d5168c153ffa23c4ba2aaac599d53da4735e0203ed072df49cdaa3c",
+  "originHash" : "fe0c8bfc9adc9693a30abe8ebbec099654d112531715734351248888315b2dcd",
   "pins" : [
     {
       "identity" : "indexstore-db",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe0c8bfc9adc9693a30abe8ebbec099654d112531715734351248888315b2dcd",
+  "originHash" : "715bf2976a6889689d5f109d2ea601b532045e95f2df32e3e99e1337117e9e95",
   "pins" : [
     {
       "identity" : "indexstore-db",

--- a/Sources/UnidocDB/Volumes/Unidoc.VolumeMetadata.NameFields.swift
+++ b/Sources/UnidocDB/Volumes/Unidoc.VolumeMetadata.NameFields.swift
@@ -15,7 +15,7 @@ extension Unidoc.VolumeMetadata
             projection[.id] = true
             projection[.package] = true
             projection[.version] = true
-            projection[.refname] = true
+            projection[.commit_name] = true
             projection[.display] = true
             projection[.latest] = true
             projection[.realm] = true

--- a/Sources/UnidocDB/Volumes/Unidoc.VolumeMetadata.StoredFields.swift
+++ b/Sources/UnidocDB/Volumes/Unidoc.VolumeMetadata.StoredFields.swift
@@ -17,7 +17,9 @@ extension Unidoc.VolumeMetadata
             projection[.package] = true
             projection[.version] = true
             projection[.display] = true
-            projection[.refname] = true
+            projection[.commit_name] = true
+            projection[.commit_sha1] = true
+            projection[.commit_date] = true
             projection[.patch] = true
 
             //  TODO: we only need this for top-level queries and

--- a/Sources/UnidocLinker/Unidoc.LinkerContext.swift
+++ b/Sources/UnidocLinker/Unidoc.LinkerContext.swift
@@ -111,7 +111,7 @@ extension Unidoc.LinkerContext
         let metadata:Unidoc.VolumeMetadata = .init(id: self.current.id,
             dependencies: boundaries.map(\.target),
             display: self.current.metadata.display,
-            refname: self.current.metadata.commit?.name,
+            commit: self.current.metadata.commit,
             symbol: volume,
             latest: self.current.id == latestRelease,
             realm: realm,

--- a/Sources/UnidocQueryTests/VolumeQueries.swift
+++ b/Sources/UnidocQueryTests/VolumeQueries.swift
@@ -82,7 +82,7 @@ struct VolumeQueries:Unidoc.TestBattery
 
             #expect(output.canonicalVolume?.patch == .v(0, 2, 0))
             #expect(output.principalVolume.patch == nil)
-            #expect(output.principalVolume.refname == "1.0.0-beta.1")
+            #expect(output.principalVolume.commit?.name == "1.0.0-beta.1")
             #expect(output.principalVertex?.landing != nil)
         }
     }

--- a/Sources/UnidocRecords/Volumes/Vertices/Unidoc.SnapshotDetails.swift
+++ b/Sources/UnidocRecords/Volumes/Vertices/Unidoc.SnapshotDetails.swift
@@ -21,6 +21,8 @@ extension Unidoc
         /// `Package.swift` manifest.
         public
         var requirements:[SymbolGraphMetadata.PlatformRequirement]
+
+        /// TODO: we get this from the Volume Metadata instead.
         /// The git commit hash from the symbol graph metadata.
         public
         var commit:SHA1?

--- a/Sources/UnidocUI/Endpoints/Docs/Unidoc.DocsEndpoint.PackagePage.swift
+++ b/Sources/UnidocUI/Endpoints/Docs/Unidoc.DocsEndpoint.PackagePage.swift
@@ -9,6 +9,7 @@ import Symbols
 import Unidoc
 import UnidocDB
 import UnidocRecords
+import UnixCalendar
 import UnixTime
 import URI
 
@@ -99,7 +100,7 @@ extension Unidoc.DocsEndpoint.PackagePage:Unidoc.ApicalPage
             $0[.div]
             {
                 $0.class = "chyron"
-            } = repo.chyron(now: format.time, ref: self.volume.refname)
+            } = repo.chyron(now: format.time, ref: self.volume.commit?.name)
         }
 
         main[.section] { $0.class = "notice canonical" } = self.context.canonical
@@ -231,7 +232,9 @@ extension Unidoc.DocsEndpoint.PackagePage:Unidoc.ApicalPage
                 }
             }
 
-            if  let commit:SHA1 = self.apex.snapshot.commit
+            //  TODO: we shouldn’t need the SnapshotDetails for this, after uplinking all
+            //  the volume metadata.
+            if  let commit:SHA1 = self.volume.commit?.sha1 ?? self.apex.snapshot.commit
             {
                 $0[.dt] = "Git revision"
                 $0[.dd]
@@ -248,6 +251,12 @@ extension Unidoc.DocsEndpoint.PackagePage:Unidoc.ApicalPage
 
                     $0[link: url] { $0.external(safe: false) } = "\(commit)"
                 }
+            }
+            if  let date:UnixMillisecond = self.volume.commit?.date,
+                let date:Timestamp = date.timestamp
+            {
+                $0[.dt] = "Git commit date"
+                $0[.dd] = "\(date.http)"
             }
         }
 

--- a/Sources/UnidocUI/Page contexts/Unidoc.IdentifiablePageContext.swift
+++ b/Sources/UnidocUI/Page contexts/Unidoc.IdentifiablePageContext.swift
@@ -40,7 +40,7 @@ extension Unidoc
             var media:PackageMedia = packages.principal?.media ?? .init()
             if  let repo:PackageRepo = packages.principal?.repo
             {
-                let ref:String = principal.refname ?? repo.master ?? "master"
+                let ref:String = principal.commit?.name ?? repo.master ?? "master"
                 let path:String
                 switch repo.origin
                 {

--- a/Sources/UnidocUI/Page contexts/Unidoc.VertexContext (ext).swift
+++ b/Sources/UnidocUI/Page contexts/Unidoc.VertexContext (ext).swift
@@ -67,7 +67,7 @@ extension Unidoc.VertexContext
     func link(source file:Unidoc.Scalar, line:Int? = nil) -> Unidoc.SourceLink?
     {
         guard
-        let refname:String = self[file.edition]?.refname,
+        let refname:String = self[file.edition]?.commit?.name,
         let vertex:Unidoc.FileVertex = self.vertices[file]?.vertex.file,
         let origin:Unidoc.PackageOrigin = self.repo?.origin
         else


### PR DESCRIPTION
this will allow us to label individual doc pages with a reasonably accurate “last modified/reviewed” timestamp, which is independent of when the docs were actually added to the website.